### PR TITLE
limiting the authors per IETF guidance

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -25,70 +25,6 @@
    organization="Google, Inc"
      [author.address]
      email="risher (at) google (dot com)"
-   [[author]]
-   initials="N."
-   surname="Lidzborski"
-   fullname="Nicolas Lidzborski"
-   organization="Google, Inc"
-     [author.address]
-     email="nlidz (at) google (dot com)"
-   [[author]]
-   initials="W."
-   surname="Chuang"
-   fullname="Wei Chuang"
-   organization="Google, Inc"
-     [author.address]
-     email="weihaw (at) google (dot com)"
-   [[author]]
-   initials="B."
-   surname="Long"
-   fullname="Brandon Long"
-   organization="Google, Inc"
-     [author.address]
-     email="blong (at) google (dot com)"
-   [[author]]
-   initials="B."
-   surname="Ramakrishnan"
-   fullname="Binu Ramakrishnan"
-   organization="Yahoo!, Inc"
-     [author.address]
-     email="rbinu (at) yahoo-inc (dot com)"
-   [[author]]
-   initials="A."
-   surname="Brotman"
-   fullname="Alexander Brotman"
-   organization="Comcast, Inc"
-     [author.address]
-     email="alexander_brotman (at) cable.comcast (dot com)"
-   [[author]]
-   initials="J."
-   surname="Jones"
-   fullname="Janet Jones"
-   organization="Microsoft, Inc"
-     [author.address]
-     email="janet.jones (at) microsoft (dot com)"
-   [[author]]
-   initials="F."
-   surname="Martin"
-   fullname="Franck Martin"
-   organization="LinkedIn"
-     [author.address]
-     email="fmartin (at) linkedin (dot com)"
-   [[author]]
-   initials="K."
-   surname="Umbach"
-   fullname="Klaus Umbach"
-   organization="1&1 Mail & Media Development & Technology GmbH"
-     [author.address]
-     email="klaus.umbach (at) 1und1 (dot de)"
-   [[author]]
-   initials="M."
-   surname="Laber"
-   fullname="Markus Laber"
-   organization="1&1 Mail & Media Development & Technology GmbH"
-     [author.address]
-     email="markus.laber (at) 1und1 (dot de)"
-
 %%%
 
 .# Abstract
@@ -559,6 +495,24 @@ In addition, the authors leave currently open the following details:
 
 * Whether and how more detailed "forensic reporting" should be accomplished, as
   discussed in the section _Failure_ _Reporting_.
+
+# Contributors
+This draft document could not exist without the contributions of numerous 
+individuals, who submitted content, proofread copy, provided examples and
+clarification, and authored sections.
+   
+* Alexander Brotman, Comcast, Inc: (alexander_brotman (at) cable.comcast (dot
+com))
+* Janet Jones, Microsoft, Inc: (janet.jones (at) microsoft (dot com))
+* Binu Ramakrishnan, Yahoo!, Inc: (rbinu (at) yahoo-inc (dot com))
+* Franck Martin, LinkedIn: (fmartin (at) linkedin (dot com))
+* Klaus Umbach, 1&1 Mail & Media Development & Technology GmbH: (klaus.umbach (at)
+1und1 (dot de))
+* Markus Laber, 1&1 Mail & Media Development & Technology GmbH: (markus.laber (at)
+1und1 (dot de))
+* Nicolas Lidzborski, Google, Inc: (nlidz (at) google (dot com))
+* Wei Chuang, Google, Inc: (weihaw (at) google (dot com))
+* Brandon Long, Google, Inc: (blong (at) google (dot com))
 
 # Appendix 1: Validation Pseudocode
 ~~~~~~~~~

--- a/spec.txt
+++ b/spec.txt
@@ -4,22 +4,8 @@
 
 Using TLS in Applications                                    D. Margolis
 Internet-Draft                                                 M. Risher
-Intended status: Standards Track                           N. Lidzborski
-Expires: September 19, 2016                                    W. Chuang
-                                                                 B. Long
-                                                             Google, Inc
-                                                         B. Ramakrishnan
-                                                             Yahoo!, Inc
-                                                              A. Brotman
-                                                            Comcast, Inc
-                                                                J. Jones
-                                                          Microsoft, Inc
-                                                               F. Martin
-                                                                LinkedIn
-                                                               K. Umbach
-                                                                M. Laber
-                          1&1 Mail & Media Development & Technology GmbH
-                                                          March 18, 2016
+Intended status: Standards Track                             Google, Inc
+Expires: September 19, 2016                               March 18, 2016
 
 
                      SMTP Strict Transport Security
@@ -50,14 +36,6 @@ Status of This Memo
 
    This Internet-Draft will expire on September 19, 2016.
 
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 1]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
 Copyright Notice
 
    Copyright (c) 2016 IETF Trust and the persons identified as the
@@ -73,46 +51,44 @@ Copyright Notice
    the Trust Legal Provisions and are provided without warranty as
    described in the Simplified BSD License.
 
-Table of Contents
-
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-     1.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   4
-   2.  Related Technologies  . . . . . . . . . . . . . . . . . . . .   4
-     2.1.  Differences from DANE . . . . . . . . . . . . . . . . . .   4
-     2.2.  Advantages When Used with DANE  . . . . . . . . . . . . .   4
-     2.3.  Advantages When Used Without DANE . . . . . . . . . . . .   5
-     2.4.  Disadvantages When Used Without DANE  . . . . . . . . . .   5
-   3.  Policy Semantics  . . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  Formal Definition . . . . . . . . . . . . . . . . . . . .   7
-     3.2.  Policy Expirations  . . . . . . . . . . . . . . . . . . .   9
-       3.2.1.  Policy Updates  . . . . . . . . . . . . . . . . . . .   9
-     3.3.  Policy Discovery & Authentication . . . . . . . . . . . .   9
-     3.4.  Policy Validation . . . . . . . . . . . . . . . . . . . .  10
-     3.5.  Policy Application  . . . . . . . . . . . . . . . . . . .  10
-   4.  Failure Reporting . . . . . . . . . . . . . . . . . . . . . .  12
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   7.  Future Work . . . . . . . . . . . . . . . . . . . . . . . . .  14
-   8.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  15
-   9.  Appendix 2: Domain Owner STS example record . . . . . . . . .  15
-     9.1.  Example 1 . . . . . . . . . . . . . . . . . . . . . . . .  15
-     9.2.  Example 2 . . . . . . . . . . . . . . . . . . . . . . . .  15
-   10. Appendix 3: XML Schema for Failure Reports  . . . . . . . . .  16
-   11. Appendix 4: Example report  . . . . . . . . . . . . . . . . .  18
-   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     12.1.  Normative References . . . . . . . . . . . . . . . . . .  19
-     12.2.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  20
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  20
 
 
-
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 2]
+Margolis & Risher      Expires September 19, 2016               [Page 1]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Related Technologies  . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Differences from DANE . . . . . . . . . . . . . . . . . .   4
+     2.2.  Advantages When Used with DANE  . . . . . . . . . . . . .   4
+     2.3.  Advantages When Used Without DANE . . . . . . . . . . . .   4
+     2.4.  Disadvantages When Used Without DANE  . . . . . . . . . .   5
+   3.  Policy Semantics  . . . . . . . . . . . . . . . . . . . . . .   5
+     3.1.  Formal Definition . . . . . . . . . . . . . . . . . . . .   6
+     3.2.  Policy Expirations  . . . . . . . . . . . . . . . . . . .   8
+       3.2.1.  Policy Updates  . . . . . . . . . . . . . . . . . . .   8
+     3.3.  Policy Discovery & Authentication . . . . . . . . . . . .   8
+     3.4.  Policy Validation . . . . . . . . . . . . . . . . . . . .   9
+     3.5.  Policy Application  . . . . . . . . . . . . . . . . . . .   9
+   4.  Failure Reporting . . . . . . . . . . . . . . . . . . . . . .  11
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   7.  Future Work . . . . . . . . . . . . . . . . . . . . . . . . .  13
+   8.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  14
+   9.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  14
+   10. Appendix 2: Domain Owner STS example record . . . . . . . . .  15
+     10.1.  Example 1  . . . . . . . . . . . . . . . . . . . . . . .  15
+     10.2.  Example 2  . . . . . . . . . . . . . . . . . . . . . . .  15
+   11. Appendix 3: XML Schema for Failure Reports  . . . . . . . . .  16
+   12. Appendix 4: Example report  . . . . . . . . . . . . . . . . .  18
+   13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     13.1.  Normative References . . . . . . . . . . . . . . . . . .  19
+     13.2.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  20
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  20
 
 1.  Introduction
 
@@ -129,6 +105,14 @@ Internet-Draft                  SMTP-STS                      March 2016
    STARTTLS" response) or who can redirect the entire SMTP session
    (perhaps by overwriting the resolved MX record of the delivery
    domain) can perform such a downgrade or interception attack.
+
+
+
+
+Margolis & Risher      Expires September 19, 2016               [Page 2]
+
+Internet-Draft                  SMTP-STS                      March 2016
+
 
    This document defines a mechanism for recipient domains to publish
    policies specifying:
@@ -158,18 +142,6 @@ Internet-Draft                  SMTP-STS                      March 2016
    4.  failure handling: what sending MTAs should do in the case of
        policy failures
 
-
-
-
-
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 3]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
 1.1.  Terminology
 
    The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
@@ -190,6 +162,14 @@ Internet-Draft                  SMTP-STS                      March 2016
    designed to upgrade opportunistic encryption into required
    encryption.  DANE requires DNSSEC [RFC4033] for the secure delivery
    of policies; the mechanism described here presents a variant for
+
+
+
+Margolis & Risher      Expires September 19, 2016               [Page 3]
+
+Internet-Draft                  SMTP-STS                      March 2016
+
+
    systems not yet supporting DNSSEC, and specifies a method for
    reporting TLS negotiation failures.
 
@@ -215,17 +195,6 @@ Internet-Draft                  SMTP-STS                      March 2016
    DANE TLSA record for SMTP.  In these cases, the SMTP STS policy can
    additionally declare a process for failure reporting.
 
-
-
-
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 4]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
 2.3.  Advantages When Used Without DANE
 
    When deployed without a DANE TLSA record, SMTP STS offers the
@@ -247,6 +216,15 @@ Internet-Draft                  SMTP-STS                      March 2016
       send-time have no mechanism to provide recipients such metrics
       from an offline (and potentially easier-to-deploy) logs-analysis
       batch process.
+
+
+
+
+
+Margolis & Risher      Expires September 19, 2016               [Page 4]
+
+Internet-Draft                  SMTP-STS                      March 2016
+
 
 2.4.  Disadvantages When Used Without DANE
 
@@ -274,14 +252,6 @@ Internet-Draft                  SMTP-STS                      March 2016
    Domain "example.com", the recipient's SMTP STS policy can be
    retrieved from "_smtp_sts.example.com."
 
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 5]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
    (Future implementations may move to alternate methods of policy
    discovery or distribution.  See the section _Future_ _Work_ for more
    discussion.)
@@ -302,6 +272,15 @@ Internet-Draft                  SMTP-STS                      March 2016
       "_.example.com,_.example.net" indicates that mail for this domain
       might be handled by any MX whose hostname is a subdomain of
       "example.com" or "example.net."
+
+
+
+
+
+Margolis & Risher      Expires September 19, 2016               [Page 5]
+
+Internet-Draft                  SMTP-STS                      March 2016
+
 
    o  a: The mechanism to use to authenticate this policy itself.  See
       the section _Policy_ _Discovery_ _&_ _Authentication_ for more
@@ -330,14 +309,6 @@ Internet-Draft                  SMTP-STS                      March 2016
 
    o  rua: [RFC3986] URI(s) to which aggregate feedback MAY be sent
       (comma-separated plain-text list of email addresses or HTTPS
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 6]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
       endpoints, optional).  For example,
       "mailto:postmaster@example.com" or "https://example.com/sts-
       report".
@@ -362,34 +333,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Margolis, et al.       Expires September 19, 2016               [Page 7]
+Margolis & Risher      Expires September 19, 2016               [Page 6]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -445,7 +389,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016               [Page 8]
+Margolis & Risher      Expires September 19, 2016               [Page 7]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -501,7 +445,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016               [Page 9]
+Margolis & Risher      Expires September 19, 2016               [Page 8]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -557,7 +501,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 10]
+Margolis & Risher      Expires September 19, 2016               [Page 9]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -613,7 +557,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 11]
+Margolis & Risher      Expires September 19, 2016              [Page 10]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -669,7 +613,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 12]
+Margolis & Risher      Expires September 19, 2016              [Page 11]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -725,7 +669,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 13]
+Margolis & Risher      Expires September 19, 2016              [Page 12]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -781,7 +725,7 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 14]
+Margolis & Risher      Expires September 19, 2016              [Page 13]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -789,7 +733,58 @@ Internet-Draft                  SMTP-STS                      March 2016
    o  Whether and how more detailed "forensic reporting" should be
       accomplished, as discussed in the section _Failure_ _Reporting_.
 
-8.  Appendix 1: Validation Pseudocode
+8.  Contributors
+
+   This draft document could not exist without the contributions of
+   numerous individuals, who submitted content, proofread copy, provided
+   examples and clarification, and authored sections.
+
+   o  Alexander Brotman, Comcast, Inc: (alexander_brotman (at)
+      cable.comcast (dot com))
+
+   o  Janet Jones, Microsoft, Inc: (janet.jones (at) microsoft (dot
+      com))
+
+   o  Binu Ramakrishnan, Yahoo!, Inc: (rbinu (at) yahoo-inc (dot com))
+
+   o  Franck Martin, LinkedIn: (fmartin (at) linkedin (dot com))
+
+   o  Klaus Umbach, 1&1 Mail & Media Development & Technology GmbH:
+      (klaus.umbach (at) 1und1 (dot de))
+
+   o  Markus Laber, 1&1 Mail & Media Development & Technology GmbH:
+      (markus.laber (at) 1und1 (dot de))
+
+   o  Nicolas Lidzborski, Google, Inc: (nlidz (at) google (dot com))
+
+   o  Wei Chuang, Google, Inc: (weihaw (at) google (dot com))
+
+   o  Brandon Long, Google, Inc: (blong (at) google (dot com))
+
+9.  Appendix 1: Validation Pseudocode
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Margolis & Risher      Expires September 19, 2016              [Page 14]
+
+Internet-Draft                  SMTP-STS                      March 2016
+
 
       policy = policy_from_cache()
       if not policy or is_expired(policy):
@@ -808,9 +803,9 @@ Internet-Draft                  SMTP-STS                      March 2016
         if update_cache:
           cache(policy)
 
-9.  Appendix 2: Domain Owner STS example record
+10.  Appendix 2: Domain Owner STS example record
 
-9.1.  Example 1
+10.1.  Example 1
 
    The owner of example.com wishes to begin using STS with a policy that
    will solicit aggregate feedback from receivers without affecting how
@@ -829,28 +824,30 @@ Internet-Draft                  SMTP-STS                      March 2016
                             "a=dnssec; c=webpki; e=123456"
                             "rua=mailto:sts-feedback@example.com" )
 
-9.2.  Example 2
+10.2.  Example 2
 
    Similar to Example 1 above, but in _enforce_ mode.  Since the auth
    field 'a' is webpki, the sender will authenticate the policy by
+   making a HTTPS request to: [2] and compare the content with the
+   policy in the DNS. example.com is the recipient's domain.
 
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 15]
+
+
+
+Margolis & Risher      Expires September 19, 2016              [Page 15]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
-
-   making a HTTPS request to: [2] and compare the content with the
-   policy in the DNS. example.com is the recipient's domain.
 
        _smtp_sts  IN TXT ( "v=STS1; m=enforce; "
                             "mx=*mail.example.com; "
                             "a=webpki; c=webpki; e=123456"
                             "rua=mailto:sts-feedback@example.com" )
 
-10.  Appendix 3: XML Schema for Failure Reports
+11.  Appendix 3: XML Schema for Failure Reports
 
 
  <?xml version="1.0"?>
@@ -890,17 +887,17 @@ Internet-Draft                  SMTP-STS                      March 2016
     <!-- The policy that was applied at send time. -->
     <xs:complexType name="AppliedPolicyType">
       <xs:all>
+        <xs:element name="domain" type="xs:string"/>
+        <xs:element name="mx" type="xs:string"
+            minOccurs="1" />
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 16]
+Margolis & Risher      Expires September 19, 2016              [Page 16]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
 
-        <xs:element name="domain" type="xs:string"/>
-        <xs:element name="mx" type="xs:string"
-            minOccurs="1" />
         <xs:element name="constraint" type="tns:ConstraintType"/>
         <xs:element name="policy_id" type="xs:string"
       </xs:all>
@@ -946,17 +943,17 @@ Internet-Draft                  SMTP-STS                      March 2016
           <xs:element name="version"
                       type="xs:decimal"/>
           <xs:element name="report_metadata"
+                      type="tns:ReportMetadataType"/>
+          <xs:element name="applied_policy"
+                      type="tns:AppliedPolicyType"/>
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 17]
+Margolis & Risher      Expires September 19, 2016              [Page 17]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
 
-                      type="tns:ReportMetadataType"/>
-          <xs:element name="applied_policy"
-                      type="tns:AppliedPolicyType"/>
     <xs:element name="enforcement_level"
     type="tns:EnforcementLevelType"/>
           <xs:element name="record" type="tns:FailureRecordType"
@@ -966,7 +963,7 @@ Internet-Draft                  SMTP-STS                      March 2016
     </xs:element>
  </xs:schema>
 
-11.  Appendix 4: Example report
+12.  Appendix 4: Example report
 
         <feedback xmlns="http://www.example.org/smtp-sts-xml/0.1">
           <version>1</version>
@@ -999,20 +996,21 @@ Internet-Draft                  SMTP-STS                      March 2016
           </record>
         </feedback>
 
+13.  References
 
 
 
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 18]
+
+
+Margolis & Risher      Expires September 19, 2016              [Page 18]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
 
-12.  References
-
-12.1.  Normative References
+13.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
@@ -1061,7 +1059,9 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 19]
+
+
+Margolis & Risher      Expires September 19, 2016              [Page 19]
 
 Internet-Draft                  SMTP-STS                      March 2016
 
@@ -1072,7 +1072,7 @@ Internet-Draft                  SMTP-STS                      March 2016
               .17487/RFC7672, October 2015,
               <http://www.rfc-editor.org/info/rfc7672>.
 
-12.2.  URIs
+13.2.  URIs
 
    [1] https://policy._smtp_sts.example.com/current
 
@@ -1092,64 +1092,6 @@ Authors' Addresses
    Email: risher (at) google (dot com)
 
 
-   Nicolas Lidzborski
-   Google, Inc
-
-   Email: nlidz (at) google (dot com)
-
-
-   Wei Chuang
-   Google, Inc
-
-   Email: weihaw (at) google (dot com)
-
-
-   Brandon Long
-   Google, Inc
-
-   Email: blong (at) google (dot com)
-
-
-   Binu Ramakrishnan
-   Yahoo!, Inc
-
-   Email: rbinu (at) yahoo-inc (dot com)
-
-
-
-Margolis, et al.       Expires September 19, 2016              [Page 20]
-
-Internet-Draft                  SMTP-STS                      March 2016
-
-
-   Alexander Brotman
-   Comcast, Inc
-
-   Email: alexander_brotman (at) cable.comcast (dot com)
-
-
-   Janet Jones
-   Microsoft, Inc
-
-   Email: janet.jones (at) microsoft (dot com)
-
-
-   Franck Martin
-   LinkedIn
-
-   Email: fmartin (at) linkedin (dot com)
-
-
-   Klaus Umbach
-   1&1 Mail & Media Development & Technology GmbH
-
-   Email: klaus.umbach (at) 1und1 (dot de)
-
-
-   Markus Laber
-   1&1 Mail & Media Development & Technology GmbH
-
-   Email: markus.laber (at) 1und1 (dot de)
 
 
 
@@ -1173,4 +1115,6 @@ Internet-Draft                  SMTP-STS                      March 2016
 
 
 
-Margolis, et al.       Expires September 19, 2016              [Page 21]
+
+
+Margolis & Risher      Expires September 19, 2016              [Page 20]

--- a/spec.xml
+++ b/spec.xml
@@ -42,141 +42,6 @@
 <uri></uri>
 </address>
 </author>
-<author initials="N." surname="Lidzborski" fullname="Nicolas Lidzborski">
-<organization>Google, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>nlidz (at) google (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="W." surname="Chuang" fullname="Wei Chuang">
-<organization>Google, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>weihaw (at) google (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="B." surname="Long" fullname="Brandon Long">
-<organization>Google, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>blong (at) google (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="B." surname="Ramakrishnan" fullname="Binu Ramakrishnan">
-<organization>Yahoo!, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>rbinu (at) yahoo-inc (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="A." surname="Brotman" fullname="Alexander Brotman">
-<organization>Comcast, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>alexander_brotman (at) cable.comcast (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="J." surname="Jones" fullname="Janet Jones">
-<organization>Microsoft, Inc</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>janet.jones (at) microsoft (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="F." surname="Martin" fullname="Franck Martin">
-<organization>LinkedIn</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>fmartin (at) linkedin (dot com)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="K." surname="Umbach" fullname="Klaus Umbach">
-<organization>1&amp;1 Mail &amp; Media Development &amp; Technology GmbH</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>klaus.umbach (at) 1und1 (dot de)</email>
-<uri></uri>
-</address>
-</author>
-<author initials="M." surname="Laber" fullname="Markus Laber">
-<organization>1&amp;1 Mail &amp; Media Development &amp; Technology GmbH</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>markus.laber (at) 1und1 (dot de)</email>
-<uri></uri>
-</address>
-</author>
 <date year="2016" month="March" day="18"/>
 
 <area>Applications</area>
@@ -715,6 +580,29 @@ restrict TLS negotiation to specific ciphers or TLS versions.</t>
 <list style="symbols">
 <t>Whether and how more detailed &quot;forensic reporting&quot; should be accomplished, as
 discussed in the section <spanx style="emph">Failure</spanx> <spanx style="emph">Reporting</spanx>.</t>
+</list>
+</t>
+</section>
+
+<section anchor="contributors" title="Contributors">
+<t>This draft document could not exist without the contributions of numerous
+individuals, who submitted content, proofread copy, provided examples and
+clarification, and authored sections.
+</t>
+<t>
+<list style="symbols">
+<t>Alexander Brotman, Comcast, Inc: (alexander_brotman (at) cable.comcast (dot
+com))</t>
+<t>Janet Jones, Microsoft, Inc: (janet.jones (at) microsoft (dot com))</t>
+<t>Binu Ramakrishnan, Yahoo!, Inc: (rbinu (at) yahoo-inc (dot com))</t>
+<t>Franck Martin, LinkedIn: (fmartin (at) linkedin (dot com))</t>
+<t>Klaus Umbach, 1&amp;1 Mail &amp; Media Development &amp; Technology GmbH: (klaus.umbach (at)
+1und1 (dot de))</t>
+<t>Markus Laber, 1&amp;1 Mail &amp; Media Development &amp; Technology GmbH: (markus.laber (at)
+1und1 (dot de))</t>
+<t>Nicolas Lidzborski, Google, Inc: (nlidz (at) google (dot com))</t>
+<t>Wei Chuang, Google, Inc: (weihaw (at) google (dot com))</t>
+<t>Brandon Long, Google, Inc: (blong (at) google (dot com))</t>
 </list>
 </t>
 </section>


### PR DESCRIPTION
The IETF folks are asking that we limit the authors to the minimum possible. Added a Contributors section (currently §9) and kept only Margolis + Risher as authors (more accurately, "editors.") WDYT?