### PR TITLE
Remove double quotes from max_age value.

### DIFF
--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -364,7 +364,7 @@ sts-mx          = %x22 "mx" $x22 *WSP %x3a *WSP       ; "mx":
                   %x5B                                ; ]
 
 sts-max_age     = %x22 "max_age" %x22 $x3a *WSP       ; "max_age":
-                  %x22 1*10DIGIT %x22$                ; some digits
+                  1*10DIGIT                           ; some digits
 
 domain-match    = (*dtext 0*1("*") *dtext) *("." 1*dtext)
                                                       ; an optional wildcard


### PR DESCRIPTION
Fixing https://github.com/mrisher/smtp-sts/issues/53 (max_age specified value should not have double quotes).