### PR TITLE
Larger refactors of DANE comparison and validation/application/control-flow sections.

### DIFF
--- a/mta-sts.md
+++ b/mta-sts.md
@@ -428,7 +428,6 @@ GET method.
 {
   "version": "STSv1",
   "mode": "report",
-  "policy_id": "randomstr",
   "mx": ["*.mail.example.com"],
   "max_age": 123456
 }

--- a/mta-sts.md
+++ b/mta-sts.md
@@ -405,8 +405,8 @@ Markus Laber
 1&1 Mail & Media Development & Technology GmbH
 markus.laber (at) 1und1 (dot de)
 
-
 # Appendix 1: Validation Pseudocode
+
 ~~~~~~~~~
 policy = policy_from_cache()
 if not policy or is_expired(policy):
@@ -448,8 +448,9 @@ _mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 ~~~~~~~~~
 
 STS policy served from HTTPS endpoint of the policy (recipient) domain, and
-is authenticated using Web PKI mechanism. The policy is fetched using HTTP
+is authenticated using the Web PKI mechanism. The policy is fetched using HTTP
 GET method.
+
 ~~~~~~~~~
 {
   "version": "STSv1",
@@ -457,8 +458,7 @@ GET method.
   "mx": ["*.mail.example.com"],
   "max_age": 123456
 }
-~~~~~~~~~
 
-The policy is authenticated using Web PKI mechanism.
+~~~~~~~~~
 
 {backmatter}

--- a/mta-sts.md
+++ b/mta-sts.md
@@ -104,57 +104,27 @@ We also define the following terms for further use in this document:
 # Related Technologies
 
 The DANE TLSA record [@!RFC7672] is similar, in that DANE is also designed to
-upgrade opportunistic encryption into required encryption. DANE requires DNSSEC
-[@!RFC4033] for the secure delivery of policies; the mechanism described here
-presents a variant for systems not yet supporting DNSSEC.
+upgrade opportunistic, unauthenticated encryption into required, authenticated
+encryption. DANE requires DNSSEC [@!RFC4033] for authentication; the mechanism
+described here instead relies on certificate authorities (CAs) and does not
+require DNSSEC.
 
 ## Differences from DANE
 
 The primary difference between the mechanism described here and DANE is that
 DANE requires the use of DNSSEC to authenticate DANE TLSA records, whereas SMTP
-STS relies on the certificate authority (CA) system to avoid interception. (For
-a thorough discussion of this trade-off, see the section _Security_
+MTA-STS relies on the certificate authority (CA) system to avoid interception.
+(For a thorough discussion of this trade-off, see the section _Security_
 _Considerations_.)
 
-In addition, SMTP MTA-STS introduces a mechanism for failure reporting and a
-report-only mode, enabling offline ("report-only") deployments and auditing for
-compliance.
-
-### Advantages of SMTP MTA-STS when compared to DANE
-
-SMTP MTA-STS offers the following advantages compared to DANE:
-
-   * Infrastructure: In comparison to DANE, this proposal does not require
-     DNSSEC be deployed on either the sending or receiving domain. In addition,
-     the reporting feature of SMTP MTA-STS can be deployed to perform offline
-     analysis of STARTTLS failures, enabling mail providers to gain insight into
-     the security of their SMTP connections without the need to modify MTA
-     codebases directly.
-   * Offline or report-only usage: DANE does not provide a reporting
-     mechanism and does not have a concept of "report-only" for failures; as a
-     result, a service provider cannot receive metrics on TLS acceptability
-     without asking senders to enforce a given policy; similarly, senders who
-     cannot enforce DANE constraints at send-time have no mechanism to provide
-     recipients such metrics from an offline (and potentially easier-to-deploy)
-     logs-analysis batch process.
-
-### Advantages of DANE when compared to SMTP MTA-STS
-
-* Infrastructure: DANE may be easier for some providers to deploy. In
-  particular, for providers who already support DNSSEC, SMTP MTA-STS would
-  additionally require they host a HTTPS webserver and obtain a CA-signed
-  X.509 certificate for the recipient domain.
-
-* Security: DANE offers an advantage against policy-lookup DoS attacks; that is,
-  while a DNSSEC-signed NXDOMAIN response to a DANE lookup authoritatively
-  indicates the lack of a DANE record, such an option to authenticate policy
-  non-existence does not exist when looking up a policy over plain DNS.
+In addition, SMTP MTA-STS provides an optional report-only mode, enabling soft
+deployments to detect policy failures.
 
 # Policy Semantics
 
 SMTP MTA-STS policies are distributed via a "well known" HTTPS endpoint in the
-Policy Domain. A corresponding TXT record in the DNS alerts sending MTAs to
-the presence of a policy file.
+Policy Domain. A corresponding TXT record in the DNS signals to sending MTAs the
+presence of a policy file.
 
 **The MTA-STS TXT record MUST specify the following fields:**
 
@@ -162,8 +132,7 @@ the presence of a policy file.
 * `id`: (plain-text, required). A short string used to track policy updates.
   This string MUST uniquely identify a given instance of a policy, such that 
   senders can determine when the policy has been updated by comparing to the `id`
-  of a previously seen policy, and must also match the `policy_id` value of the
-  distributed policy.
+  of a previously seen policy.
 
 A lenient parser SHOULD accept a policy file implementing a superset of this
 specification, in which case unknown values SHALL be ignored.
@@ -185,10 +154,6 @@ specification, in which case unknown values SHALL be ignored.
 * `max_age`: Max lifetime of the policy (plain-text integer seconds). Well-behaved
   clients SHOULD cache a policy for up to this value from last policy fetch
   time.
-* `policy_id`: A short string used to track policy updates. This string MUST
-  uniquely identify a given instance of a policy, such that senders can
-  determine when the policy has been updated by comparing to the `policy_id` of
-  a previously seen policy.
 
 A lenient parser SHOULD accept a policy file which is valid JSON implementing a
 superset of this specification, in which case unknown values SHALL be ignored.
@@ -229,9 +194,6 @@ follows:
     sts-mode        = %x22 "mode" %x22 *WSP %x3a *WSP    ; "mode":
                       %x22 ("report" / "enforce") %x22   ; "report"/"enforce"
 
-    sts-id          = %x22 "policy_id" %x22 *WSP %x3a *WSP ; "policy_id":
-                      %x22 1*32(ALPHA / DIGIT) %x22        ; some chars
-
     sts-mx          = %x22 "mx" $x22 *WSP %x3a *WSP      ; "mx":
                       %x5B                               ; [
                       domain-match                       ; comma-separated list
@@ -246,12 +208,6 @@ follows:
 
     dtext           = ALPHA / DIGIT / %2D                ; A-Z, a-z, 0-9, "-" 
 
-A size limitation in a sts-uri, if provided, is interpreted as a
-count of units followed by an OPTIONAL unit size ("k" for kilobytes,
-"m" for megabytes, "g" for gigabytes, "t" for terabytes).  Without a
-unit, the number is presumed to be a basic byte count.  Note that the
-units are considered to be powers of two; a kilobyte is 2^10, a
-megabyte is 2^20, etc.
 
 ## Policy Expiration
 
@@ -270,7 +226,7 @@ treating a validation failure as a permanent delivery failure.
 ### Policy Updates
 
 Updating the policy requires that the owner make changes in two places: the
-`_mta_sts` RR record in the Policy Domain's DNS zone and at the corresponding
+`_mta_sts` TXT record in the Policy Domain's DNS zone and at the corresponding
 HTTPS endpoint. In the case where the HTTPS endpoint has been updated but the
 TXT record has not been, senders will not know there is a new policy released
 and may thus continue to use old, previously cached versions.  Recipients should
@@ -279,24 +235,24 @@ and TXT endpoints are updated and the TXT record's TTL has passed.
 
 ## Policy Discovery & Authentication
 
-Senders discover a recipient domain's STS policy, by making an attempt to fetch
-TXT records from the recipient domain's DNS zone with the name "_mta_sts". A
-valid TXT record presence in "_mta_sts.example.com" indicates that the recipent
-domain supports STS.  To allow recipient domains to safely serve new policies,
-it is important that senders are able to authenticate a new policy retrieved for
-a recipient domain.
+Senders discover a recipient domain's MTA-STS policy by fetching a TXT record
+from the recipient domain's DNS zone with the name `_mta_sts`. A valid TXT
+record at `_mta_sts.example.com` indicates that the domain `example.com`
+supports MTA-STS.
 
-Web PKI is the mechanism used for policy authentication. In this mechanism, the
-sender fetches a HTTPS resource (policy) from a host at `policy.mta-sts` in the
-Policy Domain. The policy is served from a "well known" URI:
-`https://policy.mta-sts.example.com/.well-known/mta-sts/current`. To consider 
-the policy as valid, the `policy_id` field in the policy MUST match the `id` 
-field in the DNS TXT record under `_mta_sts`.
+When sending to a recipient domain for which a valid TXT record exists, a
+compliant sender will then fetch an HTTPS resource containing the policy body
+from a host at the `policy.mta-sts` subdomain of the policy domain, using a
+"well-known" path of `.well-known/mta-sts/current`. For `example.com`, this
+would be `https://policy.mta-sts.example.com/.well-known/mta-sts/current`.
 
-When fetching a new policy or updating a policy, the new policy MUST be
-fully authenticated (HTTPS certificate validation + peer verification) before
-use.  A policy which has not ever been successfully authenticated MUST NOT be
-used to reject mail.
+When fetching a new policy or updating a policy, the HTTPS endpoint MUST present
+a TLS certificate which is valid for the `policy.mta-sts` host (as described in
+[@!RFC6125]), chain to a root CA that is trusted by the sending CA, and be
+non-expired.
+
+A policy which has not ever been successfully authenticated MUST NOT be used to
+reject mail.
 
 ## Policy Validation
 
@@ -308,59 +264,63 @@ for the MX name and chain to a root CA that is trusted by the sending MTA. The
 certificate MUST have a CN or SAN matching the MX hostname (as described in
 [@!RFC6125]) and be non-expired.
 
+Note that this section does not dictate the behavior of sending MTAs when
+policies fail to validate; in particular, validation failures of policies which
+specify "report only" mode MUST NOT be interpreted as delivery failures, as
+described in the section _Policy_ _Application_.
+
 ## Policy Application
 
-When sending to an MX at a domain for which the sender has a valid non-expired
+When sending to an MX at a domain for which the sender has a valid, non-expired
 SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS MAY apply the result
-of a policy validation one of two ways:
+of a policy validation one of two ways, depending on the value of the policy
+`mode` field:
 
-* `report`: In this mode, sending MTAs merely send a report to the designated
-  report address indicating policy application failures. This can be done
-  "offline", i.e. based on the MTA logs, and is thus a suitable low-risk option
-  for MTAs who wish to enhance transparency of TLS tampering without making
-  complicated changes to production mail-handling infrastructure.
+* `report`: In this mode, sending MTAs merely send a report (as described in the
+  `TLSRPT` specification (TODO: add ref)) indicating policy application
+  failures. This can be used for "soft" deployments, to ensure a policy will not
+  cause domain-wide mail delivery failures while being adopted or during
+  infrastructure changes.
 
-* `enforce`: In this mode, sending MTAs SHOULD treat STS policy failures, in
-  which the policy action is "reject", as a mail delivery error, and SHOULD
-  terminate the SMTP connection, not delivering any more mail to the recipient
-  MTA.
+* `enforce`: In this mode, sending MTAs SHOULD treat STS policy failures as a
+  mail delivery error, and SHOULD not deliver the message to this host. However,
+  note that MTAs that honor `enforce` mode MUST first check for the existing of
+  an updated, authenticated policy before *permanently* failing deliveries. This
+  is to ensure that failures only occur if a sending MTA is in fact validating
+  against the most recent version of the recipient domain's policy.
 
-In `enforce` mode, however, sending MTAs MUST first check for a new
-authenticated policy before actually treating a message failure as fatal.
+### MX Preference in Enforce Mode
 
-Thus the control flow for a sending MTA that does online policy application
-consists of the following steps:
+When applying a policy specifying `enforce` mode, sending MTAs SHOULD select
+recipient MXs by first eliminating any non-matching (as specified by the policy)
+MX hosts from the candidate MX RRSet and then attempting delivery to matching
+hosts as indicated by their MX priority, until delivery succeeds or the MX
+candidate set is empty.
 
-1. Check for cached non-expired policy. If none exists, fetch the latest,
-   authenticate and cache it.
-2. Validate recipient MTA against policy. If valid, deliver mail.
-3. If not valid and the policy specifies reporting, generate report.
-4. If not valid and policy specifies rejection, perform the following
-   steps:
+If none of the attempted MX hosts validate according to the policy, the policy
+MUST be refreshed at least once, as described in _Policy_ _Discovery_ _&_
+_Authentication_, before a message should be permanently rejected.
 
-  * Check for a new (non-cached) authenticated policy.
-  * If one exists and the new policy is different, update the current policy and
-    go to step 2.
-  * If one exists and the new policy is same as the cached policy, treat the
-    delivery as a failure.
-  * If none exists and cached policy is not expired, treat the delivery as a
-    failure.
+### Policy Application Control Flow
 
-Understanding the details of step 4 is critical to understanding the behavior of
-the system as a whole.
+The control flow for a sending MTA consists of the following steps:
 
-Remember that each policy has an expiration time (which SHOULD be long, on the
-order of days or months) and a validation method. With these two mechanisms and
-the procedure specified in step 4, recipients who publish a policy have, in
-effect, a means of updating a cached policy at arbitrary intervals, without the
-risks (of a man-in-the-middle attack) they would incur if they were to shorten
-the policy expiration time.
+1. Check for a cached, non-expired policy. If none exists and the `_mta_sts` TXT
+   record is present for the recipient domain, fetch a new policy, authenticate,
+   and cache it.
+2. Validate recipient MX or MXs against policy. If a valid MX is discovered,
+   deliver mail and mark cached policy as "successfully applied."
+3. If no valid recipient MX is found, the cached policy mode is `reject`, and
+   the cached policy has previously been successfully applied, temporarily fail
+   the message.
+4. Upon message retries, a message MAY be permanently failed following first
+   checking for the presence of a new policy (as indicated by the `id` field in
+   the `_mta_sts` TXT record).
 
 # Failure Reporting
 
 Aggregate statistics on policy failures MAY be reported using the `TLSRPT`
 reporting specification (TODO: Add Ref).
-
 
 # IANA Considerations
 

--- a/mta-sts.md
+++ b/mta-sts.md
@@ -292,10 +292,11 @@ of a policy validation one of two ways, depending on the value of the policy
 ### MX Preference in Enforce Mode
 
 When applying a policy specifying `enforce` mode, sending MTAs SHOULD select
-recipient MXs by first eliminating any non-matching (as specified by the policy)
-MX hosts from the candidate MX RRSet and then attempting delivery to matching
-hosts as indicated by their MX priority, until delivery succeeds or the MX
-candidate set is empty.
+recipient MXs by first eliminating any MXs at lower priority than the current
+host (if in the MX candidate set), then eliminating any non-matching (as
+specified by the STS policy) MX hosts from the candidate MX set, and then
+attempting delivery to matching hosts as indicated by their MX priority, until
+delivery succeeds or the MX candidate set is empty.
 
 If none of the attempted MX hosts validate according to the policy, the policy
 MUST be refreshed at least once, as described in _Policy_ _Discovery_ _&_
@@ -308,7 +309,7 @@ The control flow for a sending MTA consists of the following steps:
 1. Check for a cached, non-expired policy. If none exists and the `_mta_sts` TXT
    record is present for the recipient domain, fetch a new policy, authenticate,
    and cache it.
-2. Validate recipient MX or MXs against policy. If a valid MX is discovered,
+2. Validate candidate MX or MXs against policy. If a valid MX is discovered,
    deliver mail and mark cached policy as "successfully applied."
 3. If no valid recipient MX is found, the cached policy mode is `reject`, and
    the cached policy has previously been successfully applied, temporarily fail

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -14,7 +14,7 @@ Expires: January 9, 2017                                 B. Ramakrishnan
                                                             July 8, 2016
 
 
-                   SMTP MTA Strict Transport Security
+              SMTP MTA Strict Transport Security (MTA-STS)
                        draft-ietf-uta-mta-sts-01
 
 Abstract
@@ -81,15 +81,14 @@ Table of Contents
      3.4.  Policy Validation . . . . . . . . . . . . . . . . . . . .   7
      3.5.  Policy Application  . . . . . . . . . . . . . . . . . . .   8
        3.5.1.  MX Preference in Enforce Mode . . . . . . . . . . . .   8
-       3.5.2.  Policy Application Control Flow . . . . . . . . . . .   8
-   4.  Failure Reporting . . . . . . . . . . . . . . . . . . . . . .   9
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
-   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  10
-   8.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  10
-   9.  Appendix 2: Domain Owner STS example record . . . . . . . . .  10
-     9.1.  Example 1 . . . . . . . . . . . . . . . . . . . . . . . .  10
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  11
+       3.5.2.  Policy Application Control Flow . . . . . . . . . . .   9
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   6.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  10
+   7.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  10
+   8.  Appendix 2: Domain Owner STS example record . . . . . . . . .  11
+     8.1.  Example 1 . . . . . . . . . . . . . . . . . . . . . . . .  11
+   9.  Normative References  . . . . . . . . . . . . . . . . . . . .  11
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
@@ -105,7 +104,8 @@ Table of Contents
    (perhaps by overwriting the resolved MX record of the delivery
    domain) can perform downgrade or interception attacks.
 
-
+   This document defines a mechanism for recipient domains to publish
+   policies specifying:
 
 
 
@@ -113,9 +113,6 @@ Margolis, et al.         Expires January 9, 2017                [Page 2]
 
 Internet-Draft                   MTA-STS                       July 2016
 
-
-   This document defines a mechanism for recipient domains to publish
-   policies specifying:
 
    o  whether MTAs sending mail to this domain can expect TLS support
 
@@ -149,6 +146,8 @@ Internet-Draft                   MTA-STS                       July 2016
       sending MTA encounters different results.
 
    o  Policy Domain: The domain against which an STS Policy is defined.
+      (For example, when sending mail to "alice@example.com", the policy
+      domain is "example.com".)
 
    o  Policy Authentication: Authentication of the STS policy retrieved
       for a recipient domain by the sender.
@@ -160,6 +159,7 @@ Internet-Draft                   MTA-STS                       July 2016
    required, authenticated encryption.  DANE requires DNSSEC [RFC4033]
    for authentication; the mechanism described here instead relies on
    certificate authorities (CAs) and does not require DNSSEC.
+
 
 
 
@@ -185,7 +185,8 @@ Internet-Draft                   MTA-STS                       July 2016
 
    SMTP MTA-STS policies are distributed via a "well known" HTTPS
    endpoint in the Policy Domain.  A corresponding TXT record in the DNS
-   signals to sending MTAs the presence of a policy file.
+   signals to sending MTAs the presence of a policy file.  The character
+   content of the TXT record is encoded as US-ASCII.
 
    *The MTA-STS TXT record MUST specify the following fields:*
 
@@ -195,9 +196,6 @@ Internet-Draft                   MTA-STS                       July 2016
       updates.  This string MUST uniquely identify a given instance of a
       policy, such that senders can determine when the policy has been
       updated by comparing to the "id" of a previously seen policy.
-
-   A lenient parser SHOULD accept a policy file implementing a superset
-   of this specification, in which case unknown values SHALL be ignored.
 
    *Policies MUST specify the following fields in JSON* [RFC4627]
    *format:*
@@ -221,22 +219,29 @@ Internet-Draft                   MTA-STS                       July 2016
 
 
 
+
+
 Margolis, et al.         Expires January 9, 2017                [Page 4]
 
 Internet-Draft                   MTA-STS                       July 2016
 
 
-   o  "max_age": Max lifetime of the policy (plain-text integer
+   o  "max_age": Max lifetime of the policy (plain-text positive integer
       seconds).  Well-behaved clients SHOULD cache a policy for up to
       this value from last policy fetch time.
 
-   A lenient parser SHOULD accept a policy file which is valid JSON
+   A lenient parser SHOULD accept TXT record sand policy files which are
+   syntactically valid (i.e. valid key-value pairs or valid JSON)
    implementing a superset of this specification, in which case unknown
    values SHALL be ignored.
 
 3.1.  Formal Definition
 
 3.1.1.  TXT Record
+
+   An example TXT record is as below:
+
+            _mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 
    The formal definition of the "_mta_sts" TXT record, defined using
    [RFC5234], is as follows:
@@ -250,22 +255,17 @@ Internet-Draft                   MTA-STS                       July 2016
 
 3.1.2.  SMTP MTA-STS Policy
 
+   An example policy is as below:
+
+                      {
+                        "version": "STSv1",
+                        "mode": "enforce",
+                        "mx": ["*.mail.example.com"],
+                        "max_age": 123456
+                      }
+
    The formal definition of the SMTP MTA-STS policy, using [RFC5234], is
    as follows:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -357,10 +357,10 @@ Internet-Draft                   MTA-STS                       July 2016
    that the domain "example.com" supports MTA-STS.
 
    When sending to a recipient domain for which a valid TXT record
-   exists, a compliant sender will then fetch an HTTPS resource
-   containing the policy body from a host at the "policy.mta-sts"
-   subdomain of the policy domain, using a "well-known" path of ".well-
-   known/mta-sts/current".  For "example.com", this would be
+   exists, a compliant sender will then fetch via the GET method an
+   HTTPS resource containing the policy body from a host at the "policy
+   .mta-sts" subdomain of the policy domain, using a "well-known" path
+   of ".well-known/mta-sts/current".  For "example.com", this would be
    "https://policy.mta-sts.example.com/.well-known/mta-sts/current".
 
    When fetching a new policy or updating a policy, the HTTPS endpoint
@@ -375,8 +375,9 @@ Internet-Draft                   MTA-STS                       July 2016
 
    When sending to an MX at a domain for which the sender has a valid
    and non-expired SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-
-   STS MUST validate that the recipient MX supports STARTTLS, and offers
-   a valid PKIX based TLS certificate.  The certificate presented by the
+   STS MUST validate that the recipient MX matches the "mx" pattern from
+   the recipient domain's policy, supports STARTTLS, and offers a valid
+   PKIX based TLS certificate.  The certificate presented by the
    receiving MX MUST be valid for the MX name and chain to a root CA
    that is trusted by the sending MTA.  The certificate MUST have a CN
    or SAN matching the MX hostname (as described in [RFC6125]) and be
@@ -385,7 +386,6 @@ Internet-Draft                   MTA-STS                       July 2016
    Note that this section does not dictate the behavior of sending MTAs
    when policies fail to validate; in particular, validation failures of
    policies which specify "report only" mode MUST NOT be interpreted as
-
 
 
 
@@ -400,25 +400,32 @@ Internet-Draft                   MTA-STS                       July 2016
 3.5.  Policy Application
 
    When sending to an MX at a domain for which the sender has a valid,
-   non-expired SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS
-   MAY apply the result of a policy validation one of two ways,
-   depending on the value of the policy "mode" field:
+   non-expired STS policy, a sending MTA honoring SMTP MTA-STS applies
+   the result of a policy validation one of two ways, depending on the
+   value of the policy "mode" field:
 
-   o  "report": In this mode, sending MTAs merely send a report (as
-      described in the "TLSRPT" specification (TODO: add ref))
-      indicating policy application failures.  This can be used for
-      "soft" deployments, to ensure a policy will not cause domain-wide
-      mail delivery failures while being adopted or during
-      infrastructure changes.
+   1.  "report": In this mode, sending MTAs merely send a report (as
+       described in the "TLSRPT" specification (TODO: add ref))
+       indicating policy application failures.  This can be used for
+       "soft" deployments, to ensure a policy will not cause domain-wide
+       mail delivery failures while being adopted or during
+       infrastructure changes.
 
-   o  "enforce": In this mode, sending MTAs SHOULD treat STS policy
-      failures as a mail delivery error, and SHOULD not deliver the
-      message to this host.  However, note that MTAs that honor
-      "enforce" mode MUST first check for the existing of an updated,
-      authenticated policy before _permanently_ failing deliveries.
-      This is to ensure that failures only occur if a sending MTA is in
-      fact validating against the most recent version of the recipient
-      domain's policy.
+   2.  "enforce": In this mode, sending MTAs SHOULD treat STS policy
+       failures as a mail delivery error, and SHOULD not deliver the
+       message to this host.  However, note that MTAs that honor
+       "enforce" mode MUST first check for the existing of an updated,
+       authenticated policy before _permanently_ failing deliveries.
+       This is to ensure that failures only occur if a sending MTA is in
+       fact validating against the most recent version of the recipient
+       domain's policy.
+
+   Note that despite the presence of an "enforce" policy, STS-aware
+   sending MTAs may in some cases choose to deliver mail to non-
+   validating MXes due to external reasons, such as an inability to
+   enforce STS at send-time (i.e., some domains may validate STS
+   policies offline and only choose to report failures) or concerns
+   about the completeness of their own trusted CA list.
 
 3.5.1.  MX Preference in Enforce Mode
 
@@ -435,13 +442,6 @@ Internet-Draft                   MTA-STS                       July 2016
    _Discovery_ _&_ _Authentication_, before a message should be
    permanently rejected.
 
-3.5.2.  Policy Application Control Flow
-
-   The control flow for a sending MTA consists of the following steps:
-
-   1.  Check for a cached, non-expired policy.  If none exists and the
-       "_mta_sts" TXT record is present for the recipient domain, fetch
-       a new policy, authenticate, and cache it.
 
 
 
@@ -449,6 +449,14 @@ Margolis, et al.         Expires January 9, 2017                [Page 8]
 
 Internet-Draft                   MTA-STS                       July 2016
 
+
+3.5.2.  Policy Application Control Flow
+
+   The control flow for a sending MTA consists of the following steps:
+
+   1.  Check for a cached, non-expired policy.  If none exists and the
+       "_mta_sts" TXT record is present for the recipient domain, fetch
+       a new policy, authenticate, and cache it.
 
    2.  Validate candidate MX or MXs against policy.  If a valid MX is
        discovered, deliver mail and mark cached policy as "successfully
@@ -462,42 +470,34 @@ Internet-Draft                   MTA-STS                       July 2016
        following first checking for the presence of a new policy (as
        indicated by the "id" field in the "_mta_sts" TXT record).
 
-4.  Failure Reporting
+4.  IANA Considerations
 
-   Aggregate statistics on policy failures MAY be reported using the
-   "TLSRPT" reporting specification (TODO: Add Ref).
+   A new .well-known URI will be registered in the Well-Known URIs
+   registry as described below:
 
-5.  IANA Considerations
+   URI Suffix: mta-sts Change Controller: IETF
 
-   There are no IANA considerations at this time.
+5.  Security Considerations
 
-6.  Security Considerations
+   SMTP Strict Transport Security attempts to protect against an active
+   attacker who wishes to intercept or tamper with mail between hosts
+   who support STARTTLS.  There are two classes of attacks considered:
 
-   SMTP Strict Transport Security protects against an active attacker
-   who wishes to intercept or tamper with mail between hosts who support
-   STARTTLS.  There are two classes of attacks considered:
+   1.  Foiling TLS negotiation, for example by deleting the "250
+       STARTTLS" response from a server or altering TLS session
+       negotiation.  This would result in the SMTP session occurring
+       over plaintext, despite both parties supporting TLS.
 
-   o  Foiling TLS negotiation, for example by deleting the "250
-      STARTTLS" response from a server or altering TLS session
-      negotiation.  This would result in the SMTP session occurring over
-      plaintext, despite both parties supporting TLS.
-
-   o  Impersonating the destination mail server, whereby the sender
-      might deliver the message to an impostor, who could then monitor
-      and/or modify messages despite opportunistic TLS.  This
-      impersonation could be accomplished by spoofing the DNS MX record
-      for the recipient domain, or by redirecting client connections
-      intended for the legitimate recipient server (for example, by
-      altering BGP routing tables).
+   2.  Impersonating the destination mail server, whereby the sender
+       might deliver the message to an impostor, who could then monitor
+       and/or modify messages despite opportunistic TLS.  This
+       impersonation could be accomplished by spoofing the DNS MX record
+       for the recipient domain, or by redirecting client connections
+       intended for the legitimate recipient server (for example, by
+       altering BGP routing tables).
 
    SMTP Strict Transport Security relies on certificate validation via
    PKIX based TLS identity checking [RFC6125].  Attackers who are able
-   to obtain a valid certificate for the targeted recipient mail service
-   (e.g. by compromising a certificate authority) are thus out of scope
-   of this threat model.
-
-   Since we use DNS TXT record for policy discovery, an attacker who is
-   able to block DNS responses can suppress the discovery of an STS
 
 
 
@@ -506,11 +506,17 @@ Margolis, et al.         Expires January 9, 2017                [Page 9]
 Internet-Draft                   MTA-STS                       July 2016
 
 
+   to obtain a valid certificate for the targeted recipient mail service
+   (e.g. by compromising a certificate authority) are thus able to
+   circumvent STS authentication.
+
+   Since we use DNS TXT record for policy discovery, an attacker who is
+   able to block DNS responses can suppress the discovery of an STS
    Policy, making the Policy Domain appear not to have an STS Policy.
    The caching model described in _Policy_ _Expirations_ is designed to
    resist this attack.
 
-7.  Contributors
+6.  Contributors
 
    Nicolas Lidzborski Google, Inc nlidz (at) google (dot com)
 
@@ -526,7 +532,7 @@ Internet-Draft                   MTA-STS                       July 2016
    Markus Laber 1&1 Mail & Media Development & Technology GmbH
    markus.laber (at) 1und1 (dot de)
 
-8.  Appendix 1: Validation Pseudocode
+7.  Appendix 1: Validation Pseudocode
 
 policy = policy_from_cache()
 if not policy or is_expired(policy):
@@ -545,15 +551,9 @@ if policy:
   if update_cache:
     cache(policy)
 
-9.  Appendix 2: Domain Owner STS example record
 
-9.1.  Example 1
 
-   The owner of example.com wishes to begin using STS with a policy that
-   will solicit aggregate feedback from receivers without affecting how
-   the messages are processed, in order to:
 
-   o  Verify the identity of MXs that handle mail for this domain
 
 
 
@@ -561,6 +561,16 @@ Margolis, et al.         Expires January 9, 2017               [Page 10]
 
 Internet-Draft                   MTA-STS                       July 2016
 
+
+8.  Appendix 2: Domain Owner STS example record
+
+8.1.  Example 1
+
+   The owner of example.com wishes to begin using STS with a policy that
+   will solicit aggregate feedback from receivers without affecting how
+   the messages are processed, in order to:
+
+   o  Verify the identity of MXs that handle mail for this domain
 
    o  Confirm that its legitimate messages are sent over TLS
 
@@ -585,7 +595,7 @@ Internet-Draft                   MTA-STS                       July 2016
 
    The policy is authenticated using Web PKI mechanism.
 
-10.  Normative References
+9.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
@@ -601,6 +611,13 @@ Internet-Draft                   MTA-STS                       July 2016
               4033, DOI 10.17487/RFC4033, March 2005,
               <http://www.rfc-editor.org/info/rfc4033>.
 
+
+
+Margolis, et al.         Expires January 9, 2017               [Page 11]
+
+Internet-Draft                   MTA-STS                       July 2016
+
+
    [RFC4627]  Crockford, D., "The application/json Media Type for
               JavaScript Object Notation (JSON)", RFC 4627, DOI 10
               .17487/RFC4627, July 2006,
@@ -610,13 +627,6 @@ Internet-Draft                   MTA-STS                       July 2016
               Specifications: ABNF", STD 68, RFC 5234, DOI 10.17487/
               RFC5234, January 2008,
               <http://www.rfc-editor.org/info/rfc5234>.
-
-
-
-Margolis, et al.         Expires January 9, 2017               [Page 11]
-
-Internet-Draft                   MTA-STS                       July 2016
-
 
    [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
               Verification of Domain-Based Application Service Identity
@@ -657,6 +667,13 @@ Authors' Addresses
    Email: alexander_brotman (at) cable.comcast (dot com)
 
 
+
+
+Margolis, et al.         Expires January 9, 2017               [Page 12]
+
+Internet-Draft                   MTA-STS                       July 2016
+
+
    Janet Jones
    Microsoft, Inc
 
@@ -669,4 +686,43 @@ Authors' Addresses
 
 
 
-Margolis, et al.         Expires January 9, 2017               [Page 12]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Margolis, et al.         Expires January 9, 2017               [Page 13]

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -583,8 +583,8 @@ Internet-Draft                   MTA-STS                       July 2016
             _mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 
    STS policy served from HTTPS endpoint of the policy (recipient)
-   domain, and is authenticated using Web PKI mechanism.  The policy is
-   fetched using HTTP GET method.
+   domain, and is authenticated using the Web PKI mechanism.  The policy
+   is fetched using HTTP GET method.
 
                       {
                         "version": "STSv1",
@@ -593,7 +593,6 @@ Internet-Draft                   MTA-STS                       July 2016
                         "max_age": 123456
                       }
 
-   The policy is authenticated using Web PKI mechanism.
 
 9.  Normative References
 
@@ -610,6 +609,7 @@ Internet-Draft                   MTA-STS                       July 2016
               Rose, "DNS Security Introduction and Requirements", RFC
               4033, DOI 10.17487/RFC4033, March 2005,
               <http://www.rfc-editor.org/info/rfc4033>.
+
 
 
 

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -71,31 +71,31 @@ Table of Contents
      1.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
    2.  Related Technologies  . . . . . . . . . . . . . . . . . . . .   3
      2.1.  Differences from DANE . . . . . . . . . . . . . . . . . .   4
-       2.1.1.  Advantages of SMTP MTA-STS when compared to DANE  . .   4
-       2.1.2.  Advantages of DANE when compared to SMTP MTA-STS  . .   4
-   3.  Policy Semantics  . . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  Formal Definition . . . . . . . . . . . . . . . . . . . .   6
-       3.1.1.  TXT Record  . . . . . . . . . . . . . . . . . . . . .   6
-       3.1.2.  SMTP MTA-STS Policy . . . . . . . . . . . . . . . . .   6
-     3.2.  Policy Expiration . . . . . . . . . . . . . . . . . . . .   7
-       3.2.1.  Policy Updates  . . . . . . . . . . . . . . . . . . .   8
-     3.3.  Policy Discovery & Authentication . . . . . . . . . . . .   8
-     3.4.  Policy Validation . . . . . . . . . . . . . . . . . . . .   8
-     3.5.  Policy Application  . . . . . . . . . . . . . . . . . . .   9
-   4.  Failure Reporting . . . . . . . . . . . . . . . . . . . . . .  10
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
-   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  11
-   8.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  11
-   9.  Appendix 2: Domain Owner STS example record . . . . . . . . .  11
-     9.1.  Example 1 . . . . . . . . . . . . . . . . . . . . . . . .  11
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  12
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  13
+   3.  Policy Semantics  . . . . . . . . . . . . . . . . . . . . . .   4
+     3.1.  Formal Definition . . . . . . . . . . . . . . . . . . . .   5
+       3.1.1.  TXT Record  . . . . . . . . . . . . . . . . . . . . .   5
+       3.1.2.  SMTP MTA-STS Policy . . . . . . . . . . . . . . . . .   5
+     3.2.  Policy Expiration . . . . . . . . . . . . . . . . . . . .   6
+       3.2.1.  Policy Updates  . . . . . . . . . . . . . . . . . . .   7
+     3.3.  Policy Discovery & Authentication . . . . . . . . . . . .   7
+     3.4.  Policy Validation . . . . . . . . . . . . . . . . . . . .   7
+     3.5.  Policy Application  . . . . . . . . . . . . . . . . . . .   8
+       3.5.1.  MX Preference in Enforce Mode . . . . . . . . . . . .   8
+       3.5.2.  Policy Application Control Flow . . . . . . . . . . .   8
+   4.  Failure Reporting . . . . . . . . . . . . . . . . . . . . . .   9
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   7.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  10
+   8.  Appendix 1: Validation Pseudocode . . . . . . . . . . . . . .  10
+   9.  Appendix 2: Domain Owner STS example record . . . . . . . . .  10
+     9.1.  Example 1 . . . . . . . . . . . . . . . . . . . . . . . .  10
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  11
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
    The STARTTLS extension to SMTP [RFC3207] allows SMTP clients and
-   hosts to establish negotiate the use of a TLS channel for secure mail
+   hosts to negotiate the use of a TLS channel for secure mail
    transmission.
 
    While such _opportunistic_ encryption protocols provide a high
@@ -156,10 +156,10 @@ Internet-Draft                   MTA-STS                       July 2016
 2.  Related Technologies
 
    The DANE TLSA record [RFC7672] is similar, in that DANE is also
-   designed to upgrade opportunistic encryption into required
-   encryption.  DANE requires DNSSEC [RFC4033] for the secure delivery
-   of policies; the mechanism described here presents a variant for
-   systems not yet supporting DNSSEC.
+   designed to upgrade opportunistic, unauthenticated encryption into
+   required, authenticated encryption.  DANE requires DNSSEC [RFC4033]
+   for authentication; the mechanism described here instead relies on
+   certificate authorities (CAs) and does not require DNSSEC.
 
 
 
@@ -174,63 +174,18 @@ Internet-Draft                   MTA-STS                       July 2016
 
    The primary difference between the mechanism described here and DANE
    is that DANE requires the use of DNSSEC to authenticate DANE TLSA
-   records, whereas SMTP STS relies on the certificate authority (CA)
-   system to avoid interception.  (For a thorough discussion of this
-   trade-off, see the section _Security_ _Considerations_.)
+   records, whereas SMTP MTA-STS relies on the certificate authority
+   (CA) system to avoid interception.  (For a thorough discussion of
+   this trade-off, see the section _Security_ _Considerations_.)
 
-   In addition, SMTP MTA-STS introduces a mechanism for failure
-   reporting and a report-only mode, enabling offline ("report-only")
-   deployments and auditing for compliance.
-
-2.1.1.  Advantages of SMTP MTA-STS when compared to DANE
-
-   SMTP MTA-STS offers the following advantages compared to DANE:
-
-   o  Infrastructure: In comparison to DANE, this proposal does not
-      require DNSSEC be deployed on either the sending or receiving
-      domain.  In addition, the reporting feature of SMTP MTA-STS can be
-      deployed to perform offline analysis of STARTTLS failures,
-      enabling mail providers to gain insight into the security of their
-      SMTP connections without the need to modify MTA codebases
-      directly.
-
-   o  Offline or report-only usage: DANE does not provide a reporting
-      mechanism and does not have a concept of "report-only" for
-      failures; as a result, a service provider cannot receive metrics
-      on TLS acceptability without asking senders to enforce a given
-      policy; similarly, senders who cannot enforce DANE constraints at
-      send-time have no mechanism to provide recipients such metrics
-      from an offline (and potentially easier-to-deploy) logs-analysis
-      batch process.
-
-2.1.2.  Advantages of DANE when compared to SMTP MTA-STS
-
-   o  Infrastructure: DANE may be easier for some providers to deploy.
-      In particular, for providers who already support DNSSEC, SMTP MTA-
-      STS would additionally require they host a HTTPS webserver and
-      obtain a CA-signed X.509 certificate for the recipient domain.
-
-   o  Security: DANE offers an advantage against policy-lookup DoS
-      attacks; that is, while a DNSSEC-signed NXDOMAIN response to a
-      DANE lookup authoritatively indicates the lack of a DANE record,
-      such an option to authenticate policy non-existence does not exist
-      when looking up a policy over plain DNS.
-
-
-
-
-
-
-Margolis, et al.         Expires January 9, 2017                [Page 4]
-
-Internet-Draft                   MTA-STS                       July 2016
-
+   In addition, SMTP MTA-STS provides an optional report-only mode,
+   enabling soft deployments to detect policy failures.
 
 3.  Policy Semantics
 
    SMTP MTA-STS policies are distributed via a "well known" HTTPS
    endpoint in the Policy Domain.  A corresponding TXT record in the DNS
-   alerts sending MTAs to the presence of a policy file.
+   signals to sending MTAs the presence of a policy file.
 
    *The MTA-STS TXT record MUST specify the following fields:*
 
@@ -239,8 +194,7 @@ Internet-Draft                   MTA-STS                       July 2016
    o  "id": (plain-text, required).  A short string used to track policy
       updates.  This string MUST uniquely identify a given instance of a
       policy, such that senders can determine when the policy has been
-      updated by comparing to the "id" of a previously seen policy, and
-      must also match the "policy_id" value of the distributed policy.
+      updated by comparing to the "id" of a previously seen policy.
 
    A lenient parser SHOULD accept a policy file implementing a superset
    of this specification, in which case unknown values SHALL be ignored.
@@ -265,22 +219,16 @@ Internet-Draft                   MTA-STS                       July 2016
       ones found in the "Checking of Wildcard Certificates" rules in
       Section 6.4.3 of [RFC6125].
 
-   o  "max_age": Max lifetime of the policy (plain-text integer
-      seconds).  Well-behaved clients SHOULD cache a policy for up to
-      this value from last policy fetch time.
-
-   o  "policy_id": A short string used to track policy updates.  This
-      string MUST uniquely identify a given instance of a policy, such
-      that senders can determine when the policy has been updated by
-      comparing to the "policy_id" of a previously seen policy.
 
 
-
-
-Margolis, et al.         Expires January 9, 2017                [Page 5]
+Margolis, et al.         Expires January 9, 2017                [Page 4]
 
 Internet-Draft                   MTA-STS                       July 2016
 
+
+   o  "max_age": Max lifetime of the policy (plain-text integer
+      seconds).  Well-behaved clients SHOULD cache a policy for up to
+      this value from last policy fetch time.
 
    A lenient parser SHOULD accept a policy file which is valid JSON
    implementing a superset of this specification, in which case unknown
@@ -329,11 +277,7 @@ Internet-Draft                   MTA-STS                       July 2016
 
 
 
-
-
-
-
-Margolis, et al.         Expires January 9, 2017                [Page 6]
+Margolis, et al.         Expires January 9, 2017                [Page 5]
 
 Internet-Draft                   MTA-STS                       July 2016
 
@@ -354,9 +298,6 @@ sts-version     = %x22 "version" %x22 *WSP %x3a *WSP ; "version":
 sts-mode        = %x22 "mode" %x22 *WSP %x3a *WSP    ; "mode":
                   %x22 ("report" / "enforce") %x22   ; "report"/"enforce"
 
-sts-id          = %x22 "policy_id" %x22 *WSP %x3a *WSP ; "policy_id":
-                  %x22 1*32(ALPHA / DIGIT) %x22        ; some chars
-
 sts-mx          = %x22 "mx" $x22 *WSP %x3a *WSP      ; "mx":
                   %x5B                               ; [
                   domain-match                       ; comma-separated list
@@ -371,13 +312,6 @@ domain-match    = %x22 1*(dtext / "*") *("."         ; wildcard or label
 
 dtext           = ALPHA / DIGIT / %2D                ; A-Z, a-z, 0-9, "-"
 
-   A size limitation in a sts-uri, if provided, is interpreted as a
-   count of units followed by an OPTIONAL unit size ("k" for kilobytes,
-   "m" for megabytes, "g" for gigabytes, "t" for terabytes).  Without a
-   unit, the number is presumed to be a basic byte count.  Note that the
-   units are considered to be powers of two; a kilobyte is 2^10, a
-   megabyte is 2^20, etc.
-
 3.2.  Policy Expiration
 
    In order to resist attackers inserting a fraudulent policy, SMTP MTA-
@@ -387,13 +321,6 @@ dtext           = ALPHA / DIGIT / %2D                ; A-Z, a-z, 0-9, "-"
    a policy (and apply it to all mail to the recipient domain) until the
    policy expiration.
 
-
-
-Margolis, et al.         Expires January 9, 2017                [Page 7]
-
-Internet-Draft                   MTA-STS                       July 2016
-
-
    To mitigate the risks of long-lived cached policies (which otherwise
    may make it difficult for recipient domains to change infrastructure
    in ways which the policy forbids), domains can, at any time, publish
@@ -401,10 +328,20 @@ Internet-Draft                   MTA-STS                       July 2016
    MUST fetch a new policy before treating a validation failure as a
    permanent delivery failure.
 
+
+
+
+
+
+Margolis, et al.         Expires January 9, 2017                [Page 6]
+
+Internet-Draft                   MTA-STS                       July 2016
+
+
 3.2.1.  Policy Updates
 
    Updating the policy requires that the owner make changes in two
-   places: the "_mta_sts" RR record in the Policy Domain's DNS zone and
+   places: the "_mta_sts" TXT record in the Policy Domain's DNS zone and
    at the corresponding HTTPS endpoint.  In the case where the HTTPS
    endpoint has been updated but the TXT record has not been, senders
    will not know there is a new policy released and may thus continue to
@@ -414,26 +351,25 @@ Internet-Draft                   MTA-STS                       July 2016
 
 3.3.  Policy Discovery & Authentication
 
-   Senders discover a recipient domain's STS policy, by making an
-   attempt to fetch TXT records from the recipient domain's DNS zone
-   with the name "_mta_sts".  A valid TXT record presence in
-   "_mta_sts.example.com" indicates that the recipent domain supports
-   STS.  To allow recipient domains to safely serve new policies, it is
-   important that senders are able to authenticate a new policy
-   retrieved for a recipient domain.
+   Senders discover a recipient domain's MTA-STS policy by fetching a
+   TXT record from the recipient domain's DNS zone with the name
+   "_mta_sts".  A valid TXT record at "_mta_sts.example.com" indicates
+   that the domain "example.com" supports MTA-STS.
 
-   Web PKI is the mechanism used for policy authentication.  In this
-   mechanism, the sender fetches a HTTPS resource (policy) from a host
-   at "policy.mta-sts" in the Policy Domain.  The policy is served from
-   a "well known" URI: "https://policy.mta-sts.example.com/.well-known/
-   mta-sts/current".  To consider the policy as valid, the "policy_id"
-   field in the policy MUST match the "id" field in the DNS TXT record
-   under "_mta_sts".
+   When sending to a recipient domain for which a valid TXT record
+   exists, a compliant sender will then fetch an HTTPS resource
+   containing the policy body from a host at the "policy.mta-sts"
+   subdomain of the policy domain, using a "well-known" path of ".well-
+   known/mta-sts/current".  For "example.com", this would be
+   "https://policy.mta-sts.example.com/.well-known/mta-sts/current".
 
-   When fetching a new policy or updating a policy, the new policy MUST
-   be fully authenticated (HTTPS certificate validation + peer
-   verification) before use.  A policy which has not ever been
-   successfully authenticated MUST NOT be used to reject mail.
+   When fetching a new policy or updating a policy, the HTTPS endpoint
+   MUST present a TLS certificate which is valid for the "policy.mta-
+   sts" host (as described in [RFC6125]), chain to a root CA that is
+   trusted by the sending CA, and be non-expired.
+
+   A policy which has not ever been successfully authenticated MUST NOT
+   be used to reject mail.
 
 3.4.  Policy Validation
 
@@ -442,6 +378,70 @@ Internet-Draft                   MTA-STS                       July 2016
    STS MUST validate that the recipient MX supports STARTTLS, and offers
    a valid PKIX based TLS certificate.  The certificate presented by the
    receiving MX MUST be valid for the MX name and chain to a root CA
+   that is trusted by the sending MTA.  The certificate MUST have a CN
+   or SAN matching the MX hostname (as described in [RFC6125]) and be
+   non-expired.
+
+   Note that this section does not dictate the behavior of sending MTAs
+   when policies fail to validate; in particular, validation failures of
+   policies which specify "report only" mode MUST NOT be interpreted as
+
+
+
+
+Margolis, et al.         Expires January 9, 2017                [Page 7]
+
+Internet-Draft                   MTA-STS                       July 2016
+
+
+   delivery failures, as described in the section _Policy_
+   _Application_.
+
+3.5.  Policy Application
+
+   When sending to an MX at a domain for which the sender has a valid,
+   non-expired SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS
+   MAY apply the result of a policy validation one of two ways,
+   depending on the value of the policy "mode" field:
+
+   o  "report": In this mode, sending MTAs merely send a report (as
+      described in the "TLSRPT" specification (TODO: add ref))
+      indicating policy application failures.  This can be used for
+      "soft" deployments, to ensure a policy will not cause domain-wide
+      mail delivery failures while being adopted or during
+      infrastructure changes.
+
+   o  "enforce": In this mode, sending MTAs SHOULD treat STS policy
+      failures as a mail delivery error, and SHOULD not deliver the
+      message to this host.  However, note that MTAs that honor
+      "enforce" mode MUST first check for the existing of an updated,
+      authenticated policy before _permanently_ failing deliveries.
+      This is to ensure that failures only occur if a sending MTA is in
+      fact validating against the most recent version of the recipient
+      domain's policy.
+
+3.5.1.  MX Preference in Enforce Mode
+
+   When applying a policy specifying "enforce" mode, sending MTAs SHOULD
+   select recipient MXs by first eliminating any non-matching (as
+   specified by the policy) MX hosts from the candidate MX RRSet and
+   then attempting delivery to matching hosts as indicated by their MX
+   priority, until delivery succeeds or the MX candidate set is empty.
+
+   If none of the attempted MX hosts validate according to the policy,
+   the policy MUST be refreshed at least once, as described in _Policy_
+   _Discovery_ _&_ _Authentication_, before a message should be
+   permanently rejected.
+
+3.5.2.  Policy Application Control Flow
+
+   The control flow for a sending MTA consists of the following steps:
+
+   1.  Check for a cached, non-expired policy.  If none exists and the
+       "_mta_sts" TXT record is present for the recipient domain, fetch
+       a new policy, authenticate, and cache it.
+
+
 
 
 
@@ -450,75 +450,17 @@ Margolis, et al.         Expires January 9, 2017                [Page 8]
 Internet-Draft                   MTA-STS                       July 2016
 
 
-   that is trusted by the sending MTA.  The certificate MUST have a CN
-   or SAN matching the MX hostname (as described in [RFC6125]) and be
-   non-expired.
+   2.  Validate recipient MX or MXs against policy.  If a valid MX is
+       discovered, deliver mail and mark cached policy as "successfully
+       applied."
 
-3.5.  Policy Application
+   3.  If no valid recipient MX is found, the cached policy mode is
+       "reject", and the cached policy has previously been successfully
+       applied, temporarily fail the message.
 
-   When sending to an MX at a domain for which the sender has a valid
-   non-expired SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS
-   MAY apply the result of a policy validation one of two ways:
-
-   o  "report": In this mode, sending MTAs merely send a report to the
-      designated report address indicating policy application failures.
-      This can be done "offline", i.e. based on the MTA logs, and is
-      thus a suitable low-risk option for MTAs who wish to enhance
-      transparency of TLS tampering without making complicated changes
-      to production mail-handling infrastructure.
-
-   o  "enforce": In this mode, sending MTAs SHOULD treat STS policy
-      failures, in which the policy action is "reject", as a mail
-      delivery error, and SHOULD terminate the SMTP connection, not
-      delivering any more mail to the recipient MTA.
-
-   In "enforce" mode, however, sending MTAs MUST first check for a new
-   authenticated policy before actually treating a message failure as
-   fatal.
-
-   Thus the control flow for a sending MTA that does online policy
-   application consists of the following steps:
-
-   1.  Check for cached non-expired policy.  If none exists, fetch the
-       latest, authenticate and cache it.
-
-   2.  Validate recipient MTA against policy.  If valid, deliver mail.
-
-   3.  If not valid and the policy specifies reporting, generate report.
-
-   4.  If not valid and policy specifies rejection, perform the
-       following steps:
-
-       *  Check for a new (non-cached) authenticated policy.
-
-       *  If one exists and the new policy is different, update the
-          current policy and go to step 2.
-
-       *  If one exists and the new policy is same as the cached policy,
-          treat the delivery as a failure.
-
-
-
-
-
-Margolis, et al.         Expires January 9, 2017                [Page 9]
-
-Internet-Draft                   MTA-STS                       July 2016
-
-
-       *  If none exists and cached policy is not expired, treat the
-          delivery as a failure.
-
-   Understanding the details of step 4 is critical to understanding the
-   behavior of the system as a whole.
-
-   Remember that each policy has an expiration time (which SHOULD be
-   long, on the order of days or months) and a validation method.  With
-   these two mechanisms and the procedure specified in step 4,
-   recipients who publish a policy have, in effect, a means of updating
-   a cached policy at arbitrary intervals, without the risks (of a man-
-   in-the-middle attack) they would incur if they were to shorten the
-   policy expiration time.
+   4.  Upon message retries, a message MAY be permanently failed
+       following first checking for the presence of a new policy (as
+       indicated by the "id" field in the "_mta_sts" TXT record).
 
 4.  Failure Reporting
 
@@ -554,16 +496,16 @@ Internet-Draft                   MTA-STS                       July 2016
    (e.g. by compromising a certificate authority) are thus out of scope
    of this threat model.
 
+   Since we use DNS TXT record for policy discovery, an attacker who is
+   able to block DNS responses can suppress the discovery of an STS
 
 
 
-Margolis, et al.         Expires January 9, 2017               [Page 10]
+Margolis, et al.         Expires January 9, 2017                [Page 9]
 
 Internet-Draft                   MTA-STS                       July 2016
 
 
-   Since we use DNS TXT record for policy discovery, an attacker who is
-   able to block DNS responses can suppress the discovery of an STS
    Policy, making the Policy Domain appear not to have an STS Policy.
    The caching model described in _Policy_ _Expirations_ is designed to
    resist this attack.
@@ -611,14 +553,14 @@ if policy:
    will solicit aggregate feedback from receivers without affecting how
    the messages are processed, in order to:
 
+   o  Verify the identity of MXs that handle mail for this domain
 
 
-Margolis, et al.         Expires January 9, 2017               [Page 11]
+
+Margolis, et al.         Expires January 9, 2017               [Page 10]
 
 Internet-Draft                   MTA-STS                       July 2016
 
-
-   o  Verify the identity of MXs that handle mail for this domain
 
    o  Confirm that its legitimate messages are sent over TLS
 
@@ -669,7 +611,9 @@ Internet-Draft                   MTA-STS                       July 2016
 
 
 
-Margolis, et al.         Expires January 9, 2017               [Page 12]
+
+
+Margolis, et al.         Expires January 9, 2017               [Page 11]
 
 Internet-Draft                   MTA-STS                       July 2016
 
@@ -725,4 +669,4 @@ Authors' Addresses
 
 
 
-Margolis, et al.         Expires January 9, 2017               [Page 13]
+Margolis, et al.         Expires January 9, 2017               [Page 12]

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -423,10 +423,12 @@ Internet-Draft                   MTA-STS                       July 2016
 3.5.1.  MX Preference in Enforce Mode
 
    When applying a policy specifying "enforce" mode, sending MTAs SHOULD
-   select recipient MXs by first eliminating any non-matching (as
-   specified by the policy) MX hosts from the candidate MX RRSet and
-   then attempting delivery to matching hosts as indicated by their MX
-   priority, until delivery succeeds or the MX candidate set is empty.
+   select recipient MXs by first eliminating any MXs at lower priority
+   than the current host (if in the MX candidate set), then eliminating
+   any non-matching (as specified by the STS policy) MX hosts from the
+   candidate MX set, and then attempting delivery to matching hosts as
+   indicated by their MX priority, until delivery succeeds or the MX
+   candidate set is empty.
 
    If none of the attempted MX hosts validate according to the policy,
    the policy MUST be refreshed at least once, as described in _Policy_
@@ -443,14 +445,12 @@ Internet-Draft                   MTA-STS                       July 2016
 
 
 
-
-
 Margolis, et al.         Expires January 9, 2017                [Page 8]
 
 Internet-Draft                   MTA-STS                       July 2016
 
 
-   2.  Validate recipient MX or MXs against policy.  If a valid MX is
+   2.  Validate candidate MX or MXs against policy.  If a valid MX is
        discovered, deliver mail and mark cached policy as "successfully
        applied."
 
@@ -579,7 +579,6 @@ Internet-Draft                   MTA-STS                       July 2016
                       {
                         "version": "STSv1",
                         "mode": "report",
-                        "policy_id": "randomstr",
                         "mx": ["*.mail.example.com"],
                         "max_age": 123456
                       }
@@ -607,9 +606,10 @@ Internet-Draft                   MTA-STS                       July 2016
               .17487/RFC4627, July 2006,
               <http://www.rfc-editor.org/info/rfc4627>.
 
-
-
-
+   [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234, DOI 10.17487/
+              RFC5234, January 2008,
+              <http://www.rfc-editor.org/info/rfc5234>.
 
 
 
@@ -617,11 +617,6 @@ Margolis, et al.         Expires January 9, 2017               [Page 11]
 
 Internet-Draft                   MTA-STS                       July 2016
 
-
-   [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
-              Specifications: ABNF", STD 68, RFC 5234, DOI 10.17487/
-              RFC5234, January 2008,
-              <http://www.rfc-editor.org/info/rfc5234>.
 
    [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
               Verification of Domain-Based Application Service Identity
@@ -666,6 +661,11 @@ Authors' Addresses
    Microsoft, Inc
 
    Email: janet.jones (at) microsoft (dot com)
+
+
+
+
+
 
 
 

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -570,7 +570,7 @@ Internet-Draft                   MTA-STS                       July 2016
 
    DNS STS policy indicator TXT record:
 
-               _mta_sts  IN TXT ( "v=STSv1; id=randomstr;" )
+            _mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 
    STS policy served from HTTPS endpoint of the policy (recipient)
    domain, and is authenticated using Web PKI mechanism.  The policy is

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -513,7 +513,7 @@ processed, in order to:
 </t>
 
 <figure align="center"><artwork align="center">
-_mta_sts  IN TXT ( "v=STSv1; id=randomstr;" )
+_mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 </artwork></figure>
 <t>STS policy served from HTTPS endpoint of the policy (recipient) domain, and
 is authenticated using Web PKI mechanism. The policy is fetched using HTTP

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -370,10 +370,11 @@ against the most recent version of the recipient domain's policy.</t>
 
 <section anchor="mx-preference-in-enforce-mode" title="MX Preference in Enforce Mode">
 <t>When applying a policy specifying <spanx style="verb">enforce</spanx> mode, sending MTAs SHOULD select
-recipient MXs by first eliminating any non-matching (as specified by the policy)
-MX hosts from the candidate MX RRSet and then attempting delivery to matching
-hosts as indicated by their MX priority, until delivery succeeds or the MX
-candidate set is empty.
+recipient MXs by first eliminating any MXs at lower priority than the current
+host (if in the MX candidate set), then eliminating any non-matching (as
+specified by the STS policy) MX hosts from the candidate MX set, and then
+attempting delivery to matching hosts as indicated by their MX priority, until
+delivery succeeds or the MX candidate set is empty.
 </t>
 <t>If none of the attempted MX hosts validate according to the policy, the policy
 MUST be refreshed at least once, as described in <spanx style="emph">Policy</spanx> <spanx style="emph">Discovery</spanx> <spanx style="emph">&amp;</spanx>
@@ -389,7 +390,7 @@ MUST be refreshed at least once, as described in <spanx style="emph">Policy</spa
 <t>Check for a cached, non-expired policy. If none exists and the <spanx style="verb">_mta_sts</spanx> TXT
 record is present for the recipient domain, fetch a new policy, authenticate,
 and cache it.</t>
-<t>Validate recipient MX or MXs against policy. If a valid MX is discovered,
+<t>Validate candidate MX or MXs against policy. If a valid MX is discovered,
 deliver mail and mark cached policy as &quot;successfully applied.&quot;</t>
 <t>If no valid recipient MX is found, the cached policy mode is <spanx style="verb">reject</spanx>, and
 the cached policy has previously been successfully applied, temporarily fail
@@ -523,7 +524,6 @@ GET method.
 {
   "version": "STSv1",
   "mode": "report",
-  "policy_id": "randomstr",
   "mx": ["*.mail.example.com"],
   "max_age": 123456
 }

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -10,7 +10,7 @@
 <?rfc topblock="yes"?>
 <?rfc comments="no"?>
 <front>
-<title abbrev="MTA-STS">SMTP MTA Strict Transport Security</title>
+<title abbrev="MTA-STS">SMTP MTA Strict Transport Security (MTA-STS)</title>
 
 <author initials="D." surname="Margolis" fullname="Daniel Margolis">
 <organization>Google, Inc</organization>
@@ -153,7 +153,9 @@ they appear in this document, are to be interpreted as described in <xref target
 <t>STS Policy: A definition of the expected TLS availability and behavior, as
 well as the desired actions for a given domain when a sending MTA encounters
 different results.</t>
-<t>Policy Domain: The domain against which an STS Policy is defined.</t>
+<t>Policy Domain: The domain against which an STS Policy is defined. (For
+example, when sending mail to &quot;alice@example.com&quot;, the policy domain is
+&quot;example.com&quot;.)</t>
 <t>Policy Authentication: Authentication of the STS policy retrieved for a recipient
 domain by the sender.</t>
 </list>
@@ -185,7 +187,8 @@ deployments to detect policy failures.
 <section anchor="policy-semantics" title="Policy Semantics">
 <t>SMTP MTA-STS policies are distributed via a &quot;well known&quot; HTTPS endpoint in the
 Policy Domain. A corresponding TXT record in the DNS signals to sending MTAs the
-presence of a policy file.
+presence of a policy file. The character content of the TXT record is encoded as
+US-ASCII.
 </t>
 <t><spanx style="strong">The MTA-STS TXT record MUST specify the following fields:</spanx>
 </t>
@@ -197,9 +200,6 @@ This string MUST uniquely identify a given instance of a policy, such that
 senders can determine when the policy has been updated by comparing to the <spanx style="verb">id</spanx>
 of a previously seen policy.</t>
 </list>
-</t>
-<t>A lenient parser SHOULD accept a policy file implementing a superset of this
-specification, in which case unknown values SHALL be ignored.
 </t>
 <t><spanx style="strong">Policies MUST specify the following fields in JSON</spanx> <xref target="RFC4627"/> <spanx style="strong">format:</spanx>
 </t>
@@ -217,18 +217,25 @@ domain might be handled by any MX whose hostname is a subdomain of
 &quot;example.com&quot; or &quot;example.net&quot;. The semantics for these patterns should be the
 ones found in the &quot;Checking of Wildcard Certificates&quot; rules in Section 6.4.3
 of <xref target="RFC6125"/>.</t>
-<t><spanx style="verb">max_age</spanx>: Max lifetime of the policy (plain-text integer seconds). Well-behaved
-clients SHOULD cache a policy for up to this value from last policy fetch
-time.</t>
+<t><spanx style="verb">max_age</spanx>: Max lifetime of the policy (plain-text positive integer seconds).
+Well-behaved clients SHOULD cache a policy for up to this value from last
+policy fetch time.</t>
 </list>
 </t>
-<t>A lenient parser SHOULD accept a policy file which is valid JSON implementing a
+<t>A lenient parser SHOULD accept TXT record sand policy files which are
+syntactically valid (i.e. valid key-value pairs or valid JSON) implementing a
 superset of this specification, in which case unknown values SHALL be ignored.
 </t>
 
 <section anchor="formal-definition" title="Formal Definition">
 
 <section anchor="txt-record" title="TXT Record">
+<t>An example TXT record is as below:
+</t>
+
+<figure align="center"><artwork align="center">
+_mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
+</artwork></figure>
 <t>The formal definition of the <spanx style="verb">_mta_sts</spanx> TXT record, defined using <xref target="RFC5234"/>,
 is as follows:
 </t>
@@ -244,6 +251,17 @@ sts-id          = "id" *WSP "=" *WSP 1*32(ALPHA / DIGIT)
 </section>
 
 <section anchor="smtp-mtasts-policy" title="SMTP MTA-STS Policy">
+<t>An example policy is as below:
+</t>
+
+<figure align="center"><artwork align="center">
+{
+  "version": "STSv1",
+  "mode": "enforce",
+  "mx": ["*.mail.example.com"],
+  "max_age": 123456
+}
+</artwork></figure>
 <t>The formal definition of the SMTP MTA-STS policy, using <xref target="RFC5234"/>, is as
 follows:
 </t>
@@ -315,10 +333,11 @@ record at <spanx style="verb">_mta_sts.example.com</spanx> indicates that the do
 supports MTA-STS.
 </t>
 <t>When sending to a recipient domain for which a valid TXT record exists, a
-compliant sender will then fetch an HTTPS resource containing the policy body
-from a host at the <spanx style="verb">policy.mta-sts</spanx> subdomain of the policy domain, using a
-&quot;well-known&quot; path of <spanx style="verb">.well-known/mta-sts/current</spanx>. For <spanx style="verb">example.com</spanx>, this
-would be <spanx style="verb">https://policy.mta-sts.example.com/.well-known/mta-sts/current</spanx>.
+compliant sender will then fetch via the GET method an HTTPS resource containing
+the policy body from a host at the <spanx style="verb">policy.mta-sts</spanx> subdomain of the policy
+domain, using a &quot;well-known&quot; path of <spanx style="verb">.well-known/mta-sts/current</spanx>. For
+<spanx style="verb">example.com</spanx>, this would be
+<spanx style="verb">https://policy.mta-sts.example.com/.well-known/mta-sts/current</spanx>.
 </t>
 <t>When fetching a new policy or updating a policy, the HTTPS endpoint MUST present
 a TLS certificate which is valid for the <spanx style="verb">policy.mta-sts</spanx> host (as described in
@@ -333,9 +352,10 @@ reject mail.
 <section anchor="policy-validation" title="Policy Validation">
 <t>When sending to an MX at a domain for which the sender has a valid and
 non-expired SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS MUST
-validate that the recipient MX supports STARTTLS, and offers a valid PKIX based
-TLS certificate. The certificate presented by the receiving MX MUST be valid
-for the MX name and chain to a root CA that is trusted by the sending MTA. The
+validate that the recipient MX matches the <spanx style="verb">mx</spanx> pattern from the recipient
+domain's policy, supports STARTTLS, and offers a valid PKIX based TLS
+certificate. The certificate presented by the receiving MX MUST be valid for the
+MX name and chain to a root CA that is trusted by the sending MTA. The
 certificate MUST have a CN or SAN matching the MX hostname (as described in
 <xref target="RFC6125"/>) and be non-expired.
 </t>
@@ -348,12 +368,11 @@ described in the section <spanx style="emph">Policy</spanx> <spanx style="emph">
 
 <section anchor="policy-application" title="Policy Application">
 <t>When sending to an MX at a domain for which the sender has a valid, non-expired
-SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS MAY apply the result
-of a policy validation one of two ways, depending on the value of the policy
-<spanx style="verb">mode</spanx> field:
+STS policy, a sending MTA honoring SMTP MTA-STS applies the result of a policy
+validation one of two ways, depending on the value of the policy <spanx style="verb">mode</spanx> field:
 </t>
 <t>
-<list style="symbols">
+<list style="numbers">
 <t><spanx style="verb">report</spanx>: In this mode, sending MTAs merely send a report (as described in the
 <spanx style="verb">TLSRPT</spanx> specification (TODO: add ref)) indicating policy application
 failures. This can be used for &quot;soft&quot; deployments, to ensure a policy will not
@@ -366,6 +385,12 @@ an updated, authenticated policy before <spanx style="emph">permanently</spanx> 
 is to ensure that failures only occur if a sending MTA is in fact validating
 against the most recent version of the recipient domain's policy.</t>
 </list>
+</t>
+<t>Note that despite the presence of an <spanx style="verb">enforce</spanx> policy, STS-aware sending MTAs
+may in some cases choose to deliver mail to non-validating MXes due to external
+reasons, such as an inability to enforce STS at send-time (i.e., some domains
+may validate STS policies offline and only choose to report failures) or
+concerns about the completeness of their own trusted CA list.
 </t>
 
 <section anchor="mx-preference-in-enforce-mode" title="MX Preference in Enforce Mode">
@@ -404,24 +429,22 @@ the <spanx style="verb">_mta_sts</spanx> TXT record).</t>
 </section>
 </section>
 
-<section anchor="failure-reporting" title="Failure Reporting">
-<t>Aggregate statistics on policy failures MAY be reported using the <spanx style="verb">TLSRPT</spanx>
-reporting specification (TODO: Add Ref).
-</t>
-</section>
-
 <section anchor="iana-considerations" title="IANA Considerations">
-<t>There are no IANA considerations at this time.
+<t>A new .well-known URI will be registered in the Well-Known URIs registry as
+described below:
+</t>
+<t>URI Suffix: mta-sts
+Change Controller: IETF
 </t>
 </section>
 
 <section anchor="security-considerations" title="Security Considerations">
-<t>SMTP Strict Transport Security protects against an active attacker who wishes to
-intercept or tamper with mail between hosts who support STARTTLS. There are two
-classes of attacks considered:
+<t>SMTP Strict Transport Security attempts to protect against an active attacker
+who wishes to intercept or tamper with mail between hosts who support STARTTLS.
+There are two classes of attacks considered:
 </t>
 <t>
-<list style="symbols">
+<list style="numbers">
 <t>Foiling TLS negotiation, for example by deleting the &quot;250 STARTTLS&quot; response
 from a server or altering TLS session negotiation. This would result in the
 SMTP session occurring over plaintext, despite both parties supporting TLS.</t>
@@ -436,7 +459,7 @@ altering BGP routing tables).</t>
 <t>SMTP Strict Transport Security relies on certificate validation via PKIX based TLS
 identity checking <xref target="RFC6125"/>. Attackers who are able to obtain a valid certificate
 for the targeted recipient mail service (e.g. by compromising a certificate authority)
-are thus out of scope of this threat model.
+are thus able to circumvent STS authentication.
 </t>
 <t>Since we use DNS TXT record for policy discovery, an attacker who is able to
 block DNS responses can suppress the discovery of an STS Policy, making the

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -539,7 +539,7 @@ processed, in order to:
 _mta_sts  IN TXT ( "v=STSv1; id=20160831085700Z;" )
 </artwork></figure>
 <t>STS policy served from HTTPS endpoint of the policy (recipient) domain, and
-is authenticated using Web PKI mechanism. The policy is fetched using HTTP
+is authenticated using the Web PKI mechanism. The policy is fetched using HTTP
 GET method.
 </t>
 
@@ -550,9 +550,8 @@ GET method.
   "mx": ["*.mail.example.com"],
   "max_age": 123456
 }
+
 </artwork></figure>
-<t>The policy is authenticated using Web PKI mechanism.
-</t>
 </section>
 </section>
 

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -109,7 +109,7 @@ and/or refuse to deliver messages that cannot be delivered securely.
 
 <section anchor="introduction" title="Introduction">
 <t>The STARTTLS extension to SMTP <xref target="RFC3207"/> allows SMTP clients and hosts to
-establish negotiate the use of a TLS channel for secure mail transmission.
+negotiate the use of a TLS channel for secure mail transmission.
 </t>
 <t>While such <spanx style="emph">opportunistic</spanx> encryption protocols provide a high barrier against
 passive man-in-the-middle traffic interception, any attacker who can delete
@@ -163,66 +163,29 @@ domain by the sender.</t>
 
 <section anchor="related-technologies" title="Related Technologies">
 <t>The DANE TLSA record <xref target="RFC7672"/> is similar, in that DANE is also designed to
-upgrade opportunistic encryption into required encryption. DANE requires DNSSEC
-<xref target="RFC4033"/> for the secure delivery of policies; the mechanism described here
-presents a variant for systems not yet supporting DNSSEC.
+upgrade opportunistic, unauthenticated encryption into required, authenticated
+encryption. DANE requires DNSSEC <xref target="RFC4033"/> for authentication; the mechanism
+described here instead relies on certificate authorities (CAs) and does not
+require DNSSEC.
 </t>
 
 <section anchor="differences-from-dane" title="Differences from DANE">
 <t>The primary difference between the mechanism described here and DANE is that
 DANE requires the use of DNSSEC to authenticate DANE TLSA records, whereas SMTP
-STS relies on the certificate authority (CA) system to avoid interception. (For
-a thorough discussion of this trade-off, see the section <spanx style="emph">Security</spanx>
+MTA-STS relies on the certificate authority (CA) system to avoid interception.
+(For a thorough discussion of this trade-off, see the section <spanx style="emph">Security</spanx>
 <spanx style="emph">Considerations</spanx>.)
 </t>
-<t>In addition, SMTP MTA-STS introduces a mechanism for failure reporting and a
-report-only mode, enabling offline (&quot;report-only&quot;) deployments and auditing for
-compliance.
+<t>In addition, SMTP MTA-STS provides an optional report-only mode, enabling soft
+deployments to detect policy failures.
 </t>
-
-<section anchor="advantages-of-smtp-mtasts-when-compared-to-dane" title="Advantages of SMTP MTA-STS when compared to DANE">
-<t>SMTP MTA-STS offers the following advantages compared to DANE:
-</t>
-<t>
-<list style="symbols">
-<t>Infrastructure: In comparison to DANE, this proposal does not require
- DNSSEC be deployed on either the sending or receiving domain. In addition,
- the reporting feature of SMTP MTA-STS can be deployed to perform offline
- analysis of STARTTLS failures, enabling mail providers to gain insight into
- the security of their SMTP connections without the need to modify MTA
- codebases directly.</t>
-<t>Offline or report-only usage: DANE does not provide a reporting
- mechanism and does not have a concept of &quot;report-only&quot; for failures; as a
- result, a service provider cannot receive metrics on TLS acceptability
- without asking senders to enforce a given policy; similarly, senders who
- cannot enforce DANE constraints at send-time have no mechanism to provide
- recipients such metrics from an offline (and potentially easier-to-deploy)
- logs-analysis batch process.</t>
-</list>
-</t>
-</section>
-
-<section anchor="advantages-of-dane-when-compared-to-smtp-mtasts" title="Advantages of DANE when compared to SMTP MTA-STS">
-<t>
-<list style="symbols">
-<t>Infrastructure: DANE may be easier for some providers to deploy. In
-particular, for providers who already support DNSSEC, SMTP MTA-STS would
-additionally require they host a HTTPS webserver and obtain a CA-signed
-X.509 certificate for the recipient domain.</t>
-<t>Security: DANE offers an advantage against policy-lookup DoS attacks; that is,
-while a DNSSEC-signed NXDOMAIN response to a DANE lookup authoritatively
-indicates the lack of a DANE record, such an option to authenticate policy
-non-existence does not exist when looking up a policy over plain DNS.</t>
-</list>
-</t>
-</section>
 </section>
 </section>
 
 <section anchor="policy-semantics" title="Policy Semantics">
 <t>SMTP MTA-STS policies are distributed via a &quot;well known&quot; HTTPS endpoint in the
-Policy Domain. A corresponding TXT record in the DNS alerts sending MTAs to
-the presence of a policy file.
+Policy Domain. A corresponding TXT record in the DNS signals to sending MTAs the
+presence of a policy file.
 </t>
 <t><spanx style="strong">The MTA-STS TXT record MUST specify the following fields:</spanx>
 </t>
@@ -232,8 +195,7 @@ the presence of a policy file.
 <t><spanx style="verb">id</spanx>: (plain-text, required). A short string used to track policy updates.
 This string MUST uniquely identify a given instance of a policy, such that
 senders can determine when the policy has been updated by comparing to the <spanx style="verb">id</spanx>
-of a previously seen policy, and must also match the <spanx style="verb">policy_id</spanx> value of the
-distributed policy.</t>
+of a previously seen policy.</t>
 </list>
 </t>
 <t>A lenient parser SHOULD accept a policy file implementing a superset of this
@@ -258,10 +220,6 @@ of <xref target="RFC6125"/>.</t>
 <t><spanx style="verb">max_age</spanx>: Max lifetime of the policy (plain-text integer seconds). Well-behaved
 clients SHOULD cache a policy for up to this value from last policy fetch
 time.</t>
-<t><spanx style="verb">policy_id</spanx>: A short string used to track policy updates. This string MUST
-uniquely identify a given instance of a policy, such that senders can
-determine when the policy has been updated by comparing to the <spanx style="verb">policy_id</spanx> of
-a previously seen policy.</t>
 </list>
 </t>
 <t>A lenient parser SHOULD accept a policy file which is valid JSON implementing a
@@ -307,9 +265,6 @@ sts-version     = %x22 "version" %x22 *WSP %x3a *WSP ; "version":
 sts-mode        = %x22 "mode" %x22 *WSP %x3a *WSP    ; "mode":
                   %x22 ("report" / "enforce") %x22   ; "report"/"enforce"
 
-sts-id          = %x22 "policy_id" %x22 *WSP %x3a *WSP ; "policy_id":
-                  %x22 1*32(ALPHA / DIGIT) %x22        ; some chars
-
 sts-mx          = %x22 "mx" $x22 *WSP %x3a *WSP      ; "mx":
                   %x5B                               ; [
                   domain-match                       ; comma-separated list
@@ -324,13 +279,6 @@ domain-match    = %x22 1*(dtext / "*") *("."         ; wildcard or label
 
 dtext           = ALPHA / DIGIT / %2D                ; A-Z, a-z, 0-9, "-" 
 </artwork></figure>
-<t>A size limitation in a sts-uri, if provided, is interpreted as a
-count of units followed by an OPTIONAL unit size (&quot;k&quot; for kilobytes,
-&quot;m&quot; for megabytes, &quot;g&quot; for gigabytes, &quot;t&quot; for terabytes).  Without a
-unit, the number is presumed to be a basic byte count.  Note that the
-units are considered to be powers of two; a kilobyte is 2^10, a
-megabyte is 2^20, etc.
-</t>
 </section>
 </section>
 
@@ -350,7 +298,7 @@ treating a validation failure as a permanent delivery failure.
 
 <section anchor="policy-updates" title="Policy Updates">
 <t>Updating the policy requires that the owner make changes in two places: the
-<spanx style="verb">_mta_sts</spanx> RR record in the Policy Domain's DNS zone and at the corresponding
+<spanx style="verb">_mta_sts</spanx> TXT record in the Policy Domain's DNS zone and at the corresponding
 HTTPS endpoint. In the case where the HTTPS endpoint has been updated but the
 TXT record has not been, senders will not know there is a new policy released
 and may thus continue to use old, previously cached versions.  Recipients should
@@ -361,24 +309,24 @@ and TXT endpoints are updated and the TXT record's TTL has passed.
 </section>
 
 <section anchor="policy-discovery--authentication" title="Policy Discovery &amp; Authentication">
-<t>Senders discover a recipient domain's STS policy, by making an attempt to fetch
-TXT records from the recipient domain's DNS zone with the name &quot;_mta_sts&quot;. A
-valid TXT record presence in &quot;_mta_sts.example.com&quot; indicates that the recipent
-domain supports STS.  To allow recipient domains to safely serve new policies,
-it is important that senders are able to authenticate a new policy retrieved for
-a recipient domain.
+<t>Senders discover a recipient domain's MTA-STS policy by fetching a TXT record
+from the recipient domain's DNS zone with the name <spanx style="verb">_mta_sts</spanx>. A valid TXT
+record at <spanx style="verb">_mta_sts.example.com</spanx> indicates that the domain <spanx style="verb">example.com</spanx>
+supports MTA-STS.
 </t>
-<t>Web PKI is the mechanism used for policy authentication. In this mechanism, the
-sender fetches a HTTPS resource (policy) from a host at <spanx style="verb">policy.mta-sts</spanx> in the
-Policy Domain. The policy is served from a &quot;well known&quot; URI:
-<spanx style="verb">https://policy.mta-sts.example.com/.well-known/mta-sts/current</spanx>. To consider
-the policy as valid, the <spanx style="verb">policy_id</spanx> field in the policy MUST match the <spanx style="verb">id</spanx>
-field in the DNS TXT record under <spanx style="verb">_mta_sts</spanx>.
+<t>When sending to a recipient domain for which a valid TXT record exists, a
+compliant sender will then fetch an HTTPS resource containing the policy body
+from a host at the <spanx style="verb">policy.mta-sts</spanx> subdomain of the policy domain, using a
+&quot;well-known&quot; path of <spanx style="verb">.well-known/mta-sts/current</spanx>. For <spanx style="verb">example.com</spanx>, this
+would be <spanx style="verb">https://policy.mta-sts.example.com/.well-known/mta-sts/current</spanx>.
 </t>
-<t>When fetching a new policy or updating a policy, the new policy MUST be
-fully authenticated (HTTPS certificate validation + peer verification) before
-use.  A policy which has not ever been successfully authenticated MUST NOT be
-used to reject mail.
+<t>When fetching a new policy or updating a policy, the HTTPS endpoint MUST present
+a TLS certificate which is valid for the <spanx style="verb">policy.mta-sts</spanx> host (as described in
+<xref target="RFC6125"/>), chain to a root CA that is trusted by the sending CA, and be
+non-expired.
+</t>
+<t>A policy which has not ever been successfully authenticated MUST NOT be used to
+reject mail.
 </t>
 </section>
 
@@ -391,61 +339,67 @@ for the MX name and chain to a root CA that is trusted by the sending MTA. The
 certificate MUST have a CN or SAN matching the MX hostname (as described in
 <xref target="RFC6125"/>) and be non-expired.
 </t>
+<t>Note that this section does not dictate the behavior of sending MTAs when
+policies fail to validate; in particular, validation failures of policies which
+specify &quot;report only&quot; mode MUST NOT be interpreted as delivery failures, as
+described in the section <spanx style="emph">Policy</spanx> <spanx style="emph">Application</spanx>.
+</t>
 </section>
 
 <section anchor="policy-application" title="Policy Application">
-<t>When sending to an MX at a domain for which the sender has a valid non-expired
+<t>When sending to an MX at a domain for which the sender has a valid, non-expired
 SMTP MTA-STS policy, a sending MTA honoring SMTP MTA-STS MAY apply the result
-of a policy validation one of two ways:
+of a policy validation one of two ways, depending on the value of the policy
+<spanx style="verb">mode</spanx> field:
 </t>
 <t>
 <list style="symbols">
-<t><spanx style="verb">report</spanx>: In this mode, sending MTAs merely send a report to the designated
-report address indicating policy application failures. This can be done
-&quot;offline&quot;, i.e. based on the MTA logs, and is thus a suitable low-risk option
-for MTAs who wish to enhance transparency of TLS tampering without making
-complicated changes to production mail-handling infrastructure.</t>
-<t><spanx style="verb">enforce</spanx>: In this mode, sending MTAs SHOULD treat STS policy failures, in
-which the policy action is &quot;reject&quot;, as a mail delivery error, and SHOULD
-terminate the SMTP connection, not delivering any more mail to the recipient
-MTA.</t>
+<t><spanx style="verb">report</spanx>: In this mode, sending MTAs merely send a report (as described in the
+<spanx style="verb">TLSRPT</spanx> specification (TODO: add ref)) indicating policy application
+failures. This can be used for &quot;soft&quot; deployments, to ensure a policy will not
+cause domain-wide mail delivery failures while being adopted or during
+infrastructure changes.</t>
+<t><spanx style="verb">enforce</spanx>: In this mode, sending MTAs SHOULD treat STS policy failures as a
+mail delivery error, and SHOULD not deliver the message to this host. However,
+note that MTAs that honor <spanx style="verb">enforce</spanx> mode MUST first check for the existing of
+an updated, authenticated policy before <spanx style="emph">permanently</spanx> failing deliveries. This
+is to ensure that failures only occur if a sending MTA is in fact validating
+against the most recent version of the recipient domain's policy.</t>
 </list>
 </t>
-<t>In <spanx style="verb">enforce</spanx> mode, however, sending MTAs MUST first check for a new
-authenticated policy before actually treating a message failure as fatal.
+
+<section anchor="mx-preference-in-enforce-mode" title="MX Preference in Enforce Mode">
+<t>When applying a policy specifying <spanx style="verb">enforce</spanx> mode, sending MTAs SHOULD select
+recipient MXs by first eliminating any non-matching (as specified by the policy)
+MX hosts from the candidate MX RRSet and then attempting delivery to matching
+hosts as indicated by their MX priority, until delivery succeeds or the MX
+candidate set is empty.
 </t>
-<t>Thus the control flow for a sending MTA that does online policy application
-consists of the following steps:
+<t>If none of the attempted MX hosts validate according to the policy, the policy
+MUST be refreshed at least once, as described in <spanx style="emph">Policy</spanx> <spanx style="emph">Discovery</spanx> <spanx style="emph">&amp;</spanx>
+<spanx style="emph">Authentication</spanx>, before a message should be permanently rejected.
+</t>
+</section>
+
+<section anchor="policy-application-control-flow" title="Policy Application Control Flow">
+<t>The control flow for a sending MTA consists of the following steps:
 </t>
 <t>
 <list style="numbers">
-<t>Check for cached non-expired policy. If none exists, fetch the latest,
-authenticate and cache it.</t>
-<t>Validate recipient MTA against policy. If valid, deliver mail.</t>
-<t>If not valid and the policy specifies reporting, generate report.</t>
-<t>If not valid and policy specifies rejection, perform the following
-steps:
-<list style="symbols">
-<t>Check for a new (non-cached) authenticated policy.</t>
-<t>If one exists and the new policy is different, update the current policy and
-go to step 2.</t>
-<t>If one exists and the new policy is same as the cached policy, treat the
-delivery as a failure.</t>
-<t>If none exists and cached policy is not expired, treat the delivery as a
-failure.</t>
-</list></t>
+<t>Check for a cached, non-expired policy. If none exists and the <spanx style="verb">_mta_sts</spanx> TXT
+record is present for the recipient domain, fetch a new policy, authenticate,
+and cache it.</t>
+<t>Validate recipient MX or MXs against policy. If a valid MX is discovered,
+deliver mail and mark cached policy as &quot;successfully applied.&quot;</t>
+<t>If no valid recipient MX is found, the cached policy mode is <spanx style="verb">reject</spanx>, and
+the cached policy has previously been successfully applied, temporarily fail
+the message.</t>
+<t>Upon message retries, a message MAY be permanently failed following first
+checking for the presence of a new policy (as indicated by the <spanx style="verb">id</spanx> field in
+the <spanx style="verb">_mta_sts</spanx> TXT record).</t>
 </list>
 </t>
-<t>Understanding the details of step 4 is critical to understanding the behavior of
-the system as a whole.
-</t>
-<t>Remember that each policy has an expiration time (which SHOULD be long, on the
-order of days or months) and a validation method. With these two mechanisms and
-the procedure specified in step 4, recipients who publish a policy have, in
-effect, a means of updating a cached policy at arbitrary intervals, without the
-risks (of a man-in-the-middle attack) they would incur if they were to shorten
-the policy expiration time.
-</t>
+</section>
 </section>
 </section>
 


### PR DESCRIPTION
This is a somewhat larger refactor that:

1. Removes the "Advantages/Disadvantages" versus DANE sections. (I believe the compare and contrast should be obvious to well-informed readers, and I'd prefer to avoid the editorializing.)

2. Refactors the validation/application/control-flow sections to be more explicit about what sending MTAs should be doing. 

3. Removes the "policy_id" from the JSON entirely. This seems unnecessary and introduces weird race conditions (as discussed on UTA).

I've incorporated a lot of Viktor's feedback from the UTA list as well. 