### PR TITLE
Move from 'policy.mta-sts' to 'mta-sts'.

### DIFF
--- a/mta-sts.md
+++ b/mta-sts.md
@@ -265,13 +265,13 @@ supports MTA-STS.
 
 When sending to a recipient domain for which a valid TXT record exists, a
 compliant sender will then fetch via the GET method an HTTPS resource containing
-the policy body from a host at the `policy.mta-sts` subdomain of the policy
-domain, using an [@!RFC5785] "well-known" path of `.well-known/mta-sts/current`.
-For `example.com`, this would be
-`https://policy.mta-sts.example.com/.well-known/mta-sts/current`.
+the policy body from a host at the `mta-sts` host of the policy domain, using an
+[@!RFC5785] "well-known" path of `.well-known/mta-sts/current`.  For
+`example.com`, this would be
+`https://mta-sts.example.com/.well-known/mta-sts/current`.
 
 When fetching a new policy or updating a policy, the HTTPS endpoint MUST present
-a TLS certificate which is valid for the `policy.mta-sts` host (as described in
+a TLS certificate which is valid for the `mta-sts` host (as described in
 [@!RFC6125]), chain to a root CA that is trusted by the sending CA, and be
 non-expired.
 

--- a/mta-sts.txt
+++ b/mta-sts.txt
@@ -362,16 +362,15 @@ Internet-Draft                   MTA-STS                       July 2016
 
    When sending to a recipient domain for which a valid TXT record
    exists, a compliant sender will then fetch via the GET method an
-   HTTPS resource containing the policy body from a host at the "policy
-   .mta-sts" subdomain of the policy domain, using an [RFC5785] "well-
-   known" path of ".well-known/mta-sts/current".  For "example.com",
-   this would be "https://policy.mta-sts.example.com/.well-known/mta-
-   sts/current".
+   HTTPS resource containing the policy body from a host at the "mta-
+   sts" host of the policy domain, using an [RFC5785] "well-known" path
+   of ".well-known/mta-sts/current".  For "example.com", this would be
+   "https://mta-sts.example.com/.well-known/mta-sts/current".
 
    When fetching a new policy or updating a policy, the HTTPS endpoint
-   MUST present a TLS certificate which is valid for the "policy.mta-
-   sts" host (as described in [RFC6125]), chain to a root CA that is
-   trusted by the sending CA, and be non-expired.
+   MUST present a TLS certificate which is valid for the "mta-sts" host
+   (as described in [RFC6125]), chain to a root CA that is trusted by
+   the sending CA, and be non-expired.
 
    A policy which has not ever been successfully authenticated MUST NOT
    be used to reject mail.
@@ -382,6 +381,7 @@ Internet-Draft                   MTA-STS                       July 2016
    implementions may limit further attempts to a period of five minutes
    or longer per version ID, to avoid overwhelming resource-constrained
    recipients with cascading failures.
+
 
 
 

--- a/mta-sts.xml
+++ b/mta-sts.xml
@@ -338,13 +338,13 @@ supports MTA-STS.
 </t>
 <t>When sending to a recipient domain for which a valid TXT record exists, a
 compliant sender will then fetch via the GET method an HTTPS resource containing
-the policy body from a host at the <spanx style="verb">policy.mta-sts</spanx> subdomain of the policy
-domain, using an <xref target="RFC5785"/> &quot;well-known&quot; path of <spanx style="verb">.well-known/mta-sts/current</spanx>.
-For <spanx style="verb">example.com</spanx>, this would be
-<spanx style="verb">https://policy.mta-sts.example.com/.well-known/mta-sts/current</spanx>.
+the policy body from a host at the <spanx style="verb">mta-sts</spanx> host of the policy domain, using an
+<xref target="RFC5785"/> &quot;well-known&quot; path of <spanx style="verb">.well-known/mta-sts/current</spanx>.  For
+<spanx style="verb">example.com</spanx>, this would be
+<spanx style="verb">https://mta-sts.example.com/.well-known/mta-sts/current</spanx>.
 </t>
 <t>When fetching a new policy or updating a policy, the HTTPS endpoint MUST present
-a TLS certificate which is valid for the <spanx style="verb">policy.mta-sts</spanx> host (as described in
+a TLS certificate which is valid for the <spanx style="verb">mta-sts</spanx> host (as described in
 <xref target="RFC6125"/>), chain to a root CA that is trusted by the sending CA, and be
 non-expired.
 </t>


### PR DESCRIPTION
As discussed on uta, this makes it easier to use wildcard certificates (for example.com) to serve the HTTPS endpoint, though it has the downside risk of potentially allowing some unintended "fake policy" serving (e.g. the tumblr.com case). 