### PR TITLE
Improve pseudocode in Appendix 2

### DIFF
--- a/mta-sts.md
+++ b/mta-sts.md
@@ -502,16 +502,15 @@ func tryMxAccordingTo(message, mx, policy) {
   if !connection {
     return false  // Can't connect to the MX so it's not an MTA-STS error.
   }
-  status := !(tryStartTls(mx, &connection) && certMatches(connection, mx)) 
-  status = true
+  secure := true
   if !tryStartTls(mx, &connection) {
-    status = false
+    secure = false
     reportError(E_NO_VALID_TLS)
   } else if certMatches(connection, mx) {
-    status = false
+    secure = false
     reportError(E_CERT_MISMATCH)
   }
-  if status || !isEnforce(policy) {
+  if secure || !isEnforce(policy) {
     return tryDeliverMail(connection, message)
   }
   return false


### PR DESCRIPTION
While reading and trying to understand the pseudocode example in Appendix 2, I found some odd code. I haven't written the specification so I don't know the exact intention, but at least one line (line 505) appears to be a duplicate (introduced in 77f5b164b6c40749a0f2611a790ace2453b52c59, apparently while adding the `reportError` feature).

Further, I have renamed the variable `status` to `secure`, which I think more clearly indicates it's intent.

I haven't updated the .xml and .txt files as they already were outdated.