### PR TITLE
to resolve the below

### DIFF
--- a/reporting.md
+++ b/reporting.md
@@ -241,18 +241,14 @@ easier correlation of failure events.
 The list of result types will start with the minimal set below, and is expected
 to grow over time based on real-world experience. The initial set is:
 
-### Routing Failures
-
-* `mx-mismatch`: This indicates that the MX resolved for the recipient domain
-    did not match the MX constraint specified in the policy.
-
 ### Negotiation Failures
 
 * `starttls-not-supported`: This indicates that the recipient MX did not
     support STARTTLS.
 * `certificate-host-mismatch`: This indicates that the certificate presented
     did not adhere to the constraints specified in the MTA-STS or DANE policy, e.g.
-    if the CN field did not match the hostname of the MX.
+    if the MX does not match any identities listed in the Subject Alternate 
+    Name (SAN) [RFC5280].
 * `certificate-expired`: This indicates that the certificate has expired.
 * `certificate-not-trusted`: This a label that covers multiple certificate
     related failures that include, but not limited to errors such as


### PR DESCRIPTION
=== 4.3.1.  Routing Failures

Recent discussion of the STS draft suggests that the "mx" field in STS really should become a "san" field instead, with MX choice unaffected by the STS policy.  Fraudulent MX hosts will not be able (we hope) to present certificates whose SANs match the STS policy.  If so:

   o  "mx-mismatch": This indicates that the MX resolved for the
      recipient domain did not match the MX constraint specified in the
      policy.

This error condition goes away, and is subsumed by failure to match the certificate against any of the policy SAN values.  This is much cleaner, but, full disclosure, this requires more sophistication in the TLS peer-verification code to support such matching (rather than just match the literal MX host).

Postfix can already do this, but for other MTAs this would be new code.
If they're using OpenSSL, then the library has the requisite hooks as of OpenSSL 1.0.2 to match either a literal name or a sub-domain of a parent domain from a set of such names or parent domains.

   https://www.openssl.org/docs/man1.0.2/crypto/X509_check_host.html

other toolkits might not yet support an equivalent feature.

=== 4.3.2.  Negotiation Failures

   o  "certificate-host-mismatch": This indicates that the certificate
      presented did not adhere to the constraints specified in the STS
      or DANE policy, e.g.  if the CN field did not match the hostname
      of the MX.

The "CN field" is long obsolete.  It would be great if STS required compliant certificates to have a DNS SAN (rather than support legacy CN per 6125).  The STS spec is new, and really should raise the bar here.  I don't know of any CAs that omit DNS subject altnames these days.  In any case the above text should talk about SANs primarily and the CN only as an afterthought.