### PR TITLE
Pseudocode: Ignore invalid wildcards rather than abort

### DIFF
--- a/mta-sts.md
+++ b/mta-sts.md
@@ -571,7 +571,7 @@ func certMatches(connection, policy) {
       // Return if the server certificate from "connection" matches the "mx" host.
       if san[0] == '*' {
         // Invalid wildcard!
-        if san[1] != '.' return false
+        if san[1] != '.' continue
         san = san[1:]
       }
       if san[0] == '.' && HasSuffix(mx, san) {


### PR DESCRIPTION
It's not clear to me from the draft if invalid wildcards (mail*.example.com) should be ignored, or if validation should fail. I assumed the former case, and updated the pseudocode accordingly.