### PR TITLE
Fix typo: failure-error-code -> failure-reason-code

### DIFF
--- a/reporting.md
+++ b/reporting.md
@@ -1145,7 +1145,7 @@ sessions failed due to "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED".
       "receiving-ip": "203.0.113.58",
       "receiving-mx-hostname": "mx-backup.mail.company-y.example",
       "failed-session-count": 3,
-      "failure-error-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
+      "failure-reason-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
     }]
   }]
 }

--- a/reporting.txt
+++ b/reporting.txt
@@ -1721,7 +1721,7 @@ Internet-Draft                 SMTP-TLSRPT                     June 2018
          "receiving-ip": "203.0.113.58",
          "receiving-mx-hostname": "mx-backup.mail.company-y.example",
          "failed-session-count": 3,
-         "failure-error-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
+         "failure-reason-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
        }]
      }]
    }

--- a/reporting.xml
+++ b/reporting.xml
@@ -1331,7 +1331,7 @@ sessions failed due to &quot;X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED&quot;.
       "receiving-ip": "203.0.113.58",
       "receiving-mx-hostname": "mx-backup.mail.company-y.example",
       "failed-session-count": 3,
-      "failure-error-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
+      "failure-reason-code": "X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED"
     }]
   }]
 }


### PR DESCRIPTION
Typo in reporting json example.